### PR TITLE
사용자 회원가입 시 주소정보 등록 기능 추가

### DIFF
--- a/src/main/java/com/festa/controller/EventController.java
+++ b/src/main/java/com/festa/controller/EventController.java
@@ -81,7 +81,7 @@ public class EventController {
      */
     @CheckLoginStatus(auth = UserLevel.USER)
     @GetMapping("/{eventNo}")
-    public ResponseEntity<EventDTO> getInfoOfEvent(@PathVariable int eventNo) {
+    public ResponseEntity<EventDTO> getInfoOfEvent(@PathVariable long eventNo) {
         EventDTO infoOfEvent = eventService.getInfoOfEvent(eventNo);
 
         return ResponseEntity.ok(infoOfEvent);

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -107,7 +107,7 @@ public class MemberController {
      * @return {@literal ResponseEntity<HttpStatus>}
      */
     @GetMapping("/{userId}/duplicate")
-    public ResponseEntity<HttpStatus> idIsDuplicated(@RequestParam long userId) {
+    public ResponseEntity<HttpStatus> idIsDuplicated(@RequestParam String userId) {
         boolean isIdDuplicated = memberService.isUserIdExist(userId);
 
         //1을 리턴 받았다면 true이므로 id가 존재한다.
@@ -125,7 +125,7 @@ public class MemberController {
      */
     @PostMapping(value = "/login")
     public ResponseEntity<?> login(@RequestBody @Valid MemberDTO memberDTO) {
-        long userId = memberDTO.getUserId();
+        String userId = memberDTO.getUserId();
 
         boolean isIdExist = memberService.isUserIdExist(userId);
 

--- a/src/main/java/com/festa/dao/EventDAO.java
+++ b/src/main/java/com/festa/dao/EventDAO.java
@@ -14,7 +14,7 @@ public interface EventDAO {
 
     List<EventDTO> getListOfEvents(PageInfo pageInfo, int categoryCode);
 
-    EventDTO getInfoOfEvent(int eventNo);
+    EventDTO getInfoOfEvent(long eventNo);
 
     void applyForEvents(Participants participants);
 
@@ -32,11 +32,11 @@ public interface EventDAO {
 
     void cancelEvent(long userNo);
 
-    void increaseParticipants(int eventNo);
+    void increaseParticipants(long eventNo);
 
-    void reduceParticipants(int eventNo);
+    void reduceParticipants(long eventNo);
 
-    EventDTO checkNoOfParticipants(int eventNo);
+    EventDTO checkNoOfParticipants(long eventNo);
 
     boolean isParticipated(long userNo);
 

--- a/src/main/java/com/festa/dao/MemberDAO.java
+++ b/src/main/java/com/festa/dao/MemberDAO.java
@@ -14,7 +14,7 @@ public interface MemberDAO {
 
     void insertMemberAddress(MemberDTO memberDTO);
 
-    boolean isUserIdExist(long userId);
+    boolean isUserIdExist(String userId);
 
     void modifyMemberInfo(MemberInfo memberInfo);
 
@@ -28,6 +28,6 @@ public interface MemberDAO {
 
     void modifyParticipantInfo(MemberInfo memberInfo);
 
-    int getUserNoById(long userId);
+    int getUserNoById(String userId);
 
 }

--- a/src/main/java/com/festa/dao/MemberDAO.java
+++ b/src/main/java/com/festa/dao/MemberDAO.java
@@ -12,6 +12,8 @@ public interface MemberDAO {
 
     void insertMemberInfo(MemberDTO memberDTO);
 
+    void insertMemberAddress(MemberDTO memberDTO);
+
     boolean isUserIdExist(long userId);
 
     void modifyMemberInfo(MemberInfo memberInfo);

--- a/src/main/java/com/festa/dto/EventDTO.java
+++ b/src/main/java/com/festa/dto/EventDTO.java
@@ -11,7 +11,7 @@ import java.util.Date;
 @Builder
 public class EventDTO {
 
-    int eventNo;
+    long eventNo;
 
     long userNo;
 

--- a/src/main/java/com/festa/dto/MemberDTO.java
+++ b/src/main/java/com/festa/dto/MemberDTO.java
@@ -44,4 +44,33 @@ public class MemberDTO {
     @NotNull
     UserLevel userLevel;
 
+    String cityName;
+
+    String districtName;
+
+    String streetCode;
+
+    String streetName;
+
+    public MemberDTO toEntityForInfo() {
+
+        return MemberDTO.builder()
+                .userId(this.userId)
+                .userName(this.userName)
+                .password(this.password)
+                .email(this.email)
+                .phoneNo(this.phoneNo)
+                .userLevel(this.userLevel)
+                .build();
+    }
+
+    public MemberDTO toEntityForAddress() {
+
+        return MemberDTO.builder()
+                .cityName(this.cityName)
+                .districtName(this.districtName)
+                .streetCode(this.streetCode)
+                .streetName(this.streetName)
+                .build();
+    }
 }

--- a/src/main/java/com/festa/dto/MemberDTO.java
+++ b/src/main/java/com/festa/dto/MemberDTO.java
@@ -63,14 +63,4 @@ public class MemberDTO {
                 .userLevel(this.userLevel)
                 .build();
     }
-
-    public MemberDTO toEntityForAddress() {
-
-        return MemberDTO.builder()
-                .cityName(this.cityName)
-                .districtName(this.districtName)
-                .streetCode(this.streetCode)
-                .streetName(this.streetName)
-                .build();
-    }
 }

--- a/src/main/java/com/festa/dto/MemberDTO.java
+++ b/src/main/java/com/festa/dto/MemberDTO.java
@@ -22,7 +22,7 @@ public class MemberDTO {
     long userNo;
 
     @NotBlank(message = "아이디를 입력해주세요")
-    long userId;
+    String userId;
 
     @NotBlank(message = "이름을 입력해주세요")
     String userName;

--- a/src/main/java/com/festa/model/MemberInfo.java
+++ b/src/main/java/com/festa/model/MemberInfo.java
@@ -11,12 +11,12 @@ public class MemberInfo {
 
     long userNo;
 
-    int eventNo;
+    long eventNo;
 
     String userName;
 
     @Pattern(regexp = "(^02.{0}|^01.{1}|[0-9]{3})([0-9]{4})([0-9]{4})")
-    int phoneNo;
+    String phoneNo;
 
     String cityName;
 

--- a/src/main/java/com/festa/model/Participants.java
+++ b/src/main/java/com/festa/model/Participants.java
@@ -11,10 +11,10 @@ import java.util.Date;
 public class Participants {
 
     @NotNull
-    int eventNo;
+    long eventNo;
 
     @NotNull
-    int userNo;
+    long userNo;
 
     String userName;
 

--- a/src/main/java/com/festa/service/EventService.java
+++ b/src/main/java/com/festa/service/EventService.java
@@ -23,7 +23,7 @@ public class EventService {
         return eventDAO.getListOfEvents(pageInfo, categoryCode);
     }
 
-    public EventDTO getInfoOfEvent(int eventNo) {
+    public EventDTO getInfoOfEvent(long eventNo) {
         return eventDAO.getInfoOfEvent(eventNo);
     }
 

--- a/src/main/java/com/festa/service/MemberService.java
+++ b/src/main/java/com/festa/service/MemberService.java
@@ -22,7 +22,7 @@ public class MemberService {
         memberDAO.insertMemberAddress(memberAddress);
     }
 
-    public boolean isUserIdExist(long userId) {
+    public boolean isUserIdExist(String userId) {
         return memberDAO.isUserIdExist(userId);
     }
 
@@ -53,7 +53,7 @@ public class MemberService {
         memberDAO.modifyMemberInfoForWithdraw(memberDTO);
     }
 
-    public int getUserNo(long userId) {
+    public int getUserNo(String userId) {
         return memberDAO.getUserNoById(userId);
     }
 }

--- a/src/main/java/com/festa/service/MemberService.java
+++ b/src/main/java/com/festa/service/MemberService.java
@@ -4,10 +4,12 @@ import com.festa.dao.MemberDAO;
 import com.festa.dto.MemberDTO;
 import com.festa.model.MemberInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Log4j2
 @RequiredArgsConstructor
 public class MemberService {
 
@@ -18,7 +20,14 @@ public class MemberService {
         MemberDTO memberInfo = memberDTO.toEntityForInfo();
         memberDAO.insertMemberInfo(memberInfo);
 
-        MemberDTO memberAddress = memberDTO.toEntityForAddress();
+        MemberDTO memberAddress = MemberDTO.builder()
+                .userNo(memberInfo.getUserNo())
+                .cityName(memberDTO.getCityName())
+                .districtName(memberDTO.getDistrictName())
+                .streetCode(memberDTO.getStreetCode())
+                .streetName(memberDTO.getStreetName())
+                .build();
+
         memberDAO.insertMemberAddress(memberAddress);
     }
 

--- a/src/main/java/com/festa/service/MemberService.java
+++ b/src/main/java/com/festa/service/MemberService.java
@@ -13,8 +13,13 @@ public class MemberService {
 
     private final MemberDAO memberDAO;
 
+    @Transactional
     public void insertMemberInfo(MemberDTO memberDTO) {
-        memberDAO.insertMemberInfo(memberDTO);
+        MemberDTO memberInfo = memberDTO.toEntityForInfo();
+        memberDAO.insertMemberInfo(memberInfo);
+
+        MemberDTO memberAddress = memberDTO.toEntityForAddress();
+        memberDAO.insertMemberAddress(memberAddress);
     }
 
     public boolean isUserIdExist(long userId) {

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -13,7 +13,7 @@
               userLevel,
               deleted,
               deletedDate
-        )
+            )
         VALUES
             ( #{userId},
               #{userName},
@@ -23,6 +23,22 @@
               #{userLevel},
               FALSE,
               null
+            )
+    </insert>
+    
+    <insert id="insertMemberAddress" parameterType="com.festa.dto.MemberDTO">
+        INSERT INTO
+            member_address
+            (cityName,
+             districtName,
+             streetCode,
+             streetName
+            )
+        VALUES
+            ( #{cityName},
+              #{districtName},
+              #{streetCode},
+              #{streetName}
             )
     </insert>
 

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.festa.dao.MemberDAO">
 
-    <insert id="insertMemberInfo" parameterType="com.festa.dto.MemberDTO">
+    <insert id="insertMemberInfo" parameterType="com.festa.dto.MemberDTO" useGeneratedKeys="true" keyProperty="userNo">
         INSERT INTO
             members
             ( userId,
@@ -25,17 +25,19 @@
               null
             )
     </insert>
-    
+
     <insert id="insertMemberAddress" parameterType="com.festa.dto.MemberDTO">
         INSERT INTO
             member_address
-            (cityName,
+            (userNo,
+             cityName,
              districtName,
              streetCode,
              streetName
             )
         VALUES
-            ( #{cityName},
+            ( #{userNo},
+              #{cityName},
               #{districtName},
               #{streetCode},
               #{streetName}


### PR DESCRIPTION
#### 테이블 컬럼 속성 변경

<br>

주소 데이터를 insert 할 때 신규 가입일 경우 넘겨주는 memberDTO 객체에 `userNo` 값이 없는 문제가 있었습니다. 

왜냐하면,  **members** 테이블의 `userNo` 값이 auto_increment 라서 따로 값을 안넘겨줘도 되기 때문입니다.  `userNo` 값이 없으면 해당 사용자의 주소를 제대로 가져올 수 없습니다. 

그래서 **members_address** 의 `userNo` 값도 같이 auto_increment를 설정해서 신규가입이고 동시에 두 테이블에 값이 들어오기 때문에 항상 같은 `userNo`가 들어갈 것이라고 판단했습니다. 

<br>

더 좋은 방안이있다면 피드백 부탁드립니다~