### PR TITLE
회원정보 조회 오류 수정

### DIFF
--- a/src/main/java/com/festa/common/ResponseEntityConstants.java
+++ b/src/main/java/com/festa/common/ResponseEntityConstants.java
@@ -1,5 +1,6 @@
 package com.festa.common;
 
+import com.festa.dto.MemberDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -15,5 +16,5 @@ public class ResponseEntityConstants {
     public static final ResponseEntity<HttpStatus> RESPONSE_ENTITY_NO_CONTENT = ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     public static final ResponseEntity<HttpStatus> RESPONSE_ENTITY_BAD_REQUEST = ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     public static final ResponseEntity<String> RESPONSE_ENTITY_BAD_REQUEST_NO_USER = ResponseEntity.status(HttpStatus.BAD_REQUEST).body("미가입 회원입니다.");
-
+    public static final ResponseEntity<MemberDTO> RESPONSE_ENTITY_MEMBER_NULL = ResponseEntity.ok(null);
 }

--- a/src/main/java/com/festa/common/ResponseEntityConstants.java
+++ b/src/main/java/com/festa/common/ResponseEntityConstants.java
@@ -1,6 +1,5 @@
 package com.festa.common;
 
-import com.festa.dto.MemberDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -16,5 +15,5 @@ public class ResponseEntityConstants {
     public static final ResponseEntity<HttpStatus> RESPONSE_ENTITY_NO_CONTENT = ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     public static final ResponseEntity<HttpStatus> RESPONSE_ENTITY_BAD_REQUEST = ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     public static final ResponseEntity<String> RESPONSE_ENTITY_BAD_REQUEST_NO_USER = ResponseEntity.status(HttpStatus.BAD_REQUEST).body("미가입 회원입니다.");
-    public static final ResponseEntity<MemberDTO> RESPONSE_ENTITY_MEMBER_NULL = ResponseEntity.ok(null);
+    public static final ResponseEntity<HttpStatus> RESPONSE_ENTITY_MEMBER_NULL = ResponseEntity.ok(null);
 }

--- a/src/main/java/com/festa/common/SessionLogin.java
+++ b/src/main/java/com/festa/common/SessionLogin.java
@@ -2,6 +2,7 @@ package com.festa.common;
 
 import com.festa.common.commonService.LoginService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpSession;
@@ -13,6 +14,7 @@ import java.util.Optional;
  * 따로 인터페이스와 클래스로 분리시켜 둠.
  */
 
+@Log4j2
 @Component
 @RequiredArgsConstructor
 public class SessionLogin implements LoginService {

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -70,8 +70,8 @@ public class MemberController {
      * @return {@literal ResponseEntity<HttpStatus>}
      */
     @CheckLoginStatus(auth = UserLevel.USER)
-    @GetMapping(value = "/{userId}")
-    public ResponseEntity<HttpStatus> getUser(@CurrentLoginUserNo long userNo) {
+    @GetMapping(value = "/{userNo}")
+    public ResponseEntity<HttpStatus> getUser(@RequestParam long userNo) {
         MemberDTO memberInfo = memberService.getUser(userNo);
 
         if(memberInfo == null) {

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -156,8 +156,8 @@ public class MemberController {
      */
     @CheckLoginStatus(auth = UserLevel.USER)
     @PatchMapping("/{userId}/password")
-    public ResponseEntity<HttpStatus> changePassword(@CurrentLoginUserNo long userNo, @RequestBody @Valid MemberDTO memberDTO) {
-        memberService.changeUserPw(userNo, memberDTO.getPassword());
+    public ResponseEntity<HttpStatus> changePassword(@CurrentLoginUserNo long userNo, @RequestBody MemberLogin memberLogin) {
+        memberService.changeUserPw(userNo, memberLogin.getPassword());
 
         return RESPONSE_ENTITY_OK;
     }

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.festa.common.UserLevel;
 import com.festa.common.commonService.LoginService;
 import com.festa.common.commonService.CurrentLoginUserNo;
 import com.festa.dto.MemberDTO;
+import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
 import com.festa.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -117,12 +118,12 @@ public class MemberController {
 
     /**
      * 사용자 로그인 기능
-     * @param memberDTO
+     * @param memberLogin
      * @return {@literal ResponseEntity<HttpStatus>}
      */
     @PostMapping(value = "/login")
-    public ResponseEntity<?> login(@RequestBody @Valid MemberDTO memberDTO) {
-        String userId = memberDTO.getUserId();
+    public ResponseEntity<?> login(@RequestBody MemberLogin memberLogin) {
+        String userId = memberLogin.getUserId();
 
         boolean isIdExist = memberService.isUserIdExist(userId);
 
@@ -130,7 +131,7 @@ public class MemberController {
         if(!isIdExist) {
             return RESPONSE_ENTITY_BAD_REQUEST_NO_USER;
         }
-        loginService.setUserNo(memberDTO.getUserNo());
+        loginService.setUserNo(memberLogin.getUserNo());
 
         return RESPONSE_ENTITY_OK;
     }

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -25,10 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.validation.Valid;
 import java.net.URI;
 
-import static com.festa.common.ResponseEntityConstants.RESPONSE_ENTITY_BAD_REQUEST;
-import static com.festa.common.ResponseEntityConstants.RESPONSE_ENTITY_BAD_REQUEST_NO_USER;
-import static com.festa.common.ResponseEntityConstants.RESPONSE_ENTITY_CONFLICT;
-import static com.festa.common.ResponseEntityConstants.RESPONSE_ENTITY_OK;
+import static com.festa.common.ResponseEntityConstants.*;
 
 /*
  * @RestController : @Controller와 @ResponseBody를 포함하고 있는 어노테이션
@@ -67,17 +64,17 @@ public class MemberController {
     /**
      * 사용자 회원정보 조회 기능
      * @param userNo
-     * @return {@literal ResponseEntity<HttpStatus>}
+     * @return {@literal ResponseEntity<MemberDTO>}
      */
     @CheckLoginStatus(auth = UserLevel.USER)
     @GetMapping(value = "/{userNo}")
-    public ResponseEntity<HttpStatus> getUser(@RequestParam long userNo) {
+    public ResponseEntity<MemberDTO> getUser(@RequestParam long userNo) {
         MemberDTO memberInfo = memberService.getUser(userNo);
 
         if(memberInfo == null) {
-            return RESPONSE_ENTITY_BAD_REQUEST;
+            return RESPONSE_ENTITY_MEMBER_NULL;
         }
-        return RESPONSE_ENTITY_OK;
+        return ResponseEntity.ok().body(memberInfo);
     }
 
     /**

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -69,13 +69,13 @@ public class MemberController {
      */
     @CheckLoginStatus(auth = UserLevel.USER)
     @GetMapping(value = "/{userNo}")
-    public ResponseEntity<MemberDTO> getUser(@RequestParam long userNo) {
+    public ResponseEntity<HttpStatus> getUser(@RequestParam long userNo) {
         MemberDTO memberInfo = memberService.getUser(userNo);
 
         if(memberInfo == null) {
             return RESPONSE_ENTITY_MEMBER_NULL;
         }
-        return ResponseEntity.ok().body(memberInfo);
+        return RESPONSE_ENTITY_OK;
     }
 
     /**

--- a/src/main/java/com/festa/dao/MemberDAO.java
+++ b/src/main/java/com/festa/dao/MemberDAO.java
@@ -1,8 +1,8 @@
 package com.festa.dao;
 
 import com.festa.dto.MemberDTO;
+import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
-import com.festa.model.Participants;
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/festa/dto/MemberDTO.java
+++ b/src/main/java/com/festa/dto/MemberDTO.java
@@ -6,7 +6,6 @@ import lombok.Value;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 /* @Value 어노테이션을 이용하게 되면 필드에 자동으로 private final 이 붙게 되고
@@ -24,7 +23,6 @@ public class MemberDTO {
     @NotBlank(message = "아이디를 입력해주세요")
     String userId;
 
-    @NotBlank(message = "이름을 입력해주세요")
     String userName;
 
     @NotBlank(message = "비밀번호를 입력해주세요")
@@ -32,16 +30,13 @@ public class MemberDTO {
              message = "영문 대소문자와 숫자, 특수기호가 1개씩 포함되어있는 5~10자 비밀번호입니다")
     String password;
 
-    @NotBlank(message = "이메일을 입력해주세요")
     @Email
     String email;
 
-    @NotBlank(message = "전화번호를 입력해주세요")
     @Pattern(regexp = "(^02.{0}|^01.{1}|[0-9]{3})([0-9]{4})([0-9]{4})")
     String phoneNo;
 
     //정해진 값에 다른 값이 들어오는 것을 막기 위해 enum으로 관리
-    @NotNull
     UserLevel userLevel;
 
     String cityName;

--- a/src/main/java/com/festa/dto/MemberDTO.java
+++ b/src/main/java/com/festa/dto/MemberDTO.java
@@ -6,6 +6,7 @@ import lombok.Value;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 /* @Value 어노테이션을 이용하게 되면 필드에 자동으로 private final 이 붙게 되고
@@ -23,6 +24,7 @@ public class MemberDTO {
     @NotBlank(message = "아이디를 입력해주세요")
     String userId;
 
+    @NotBlank(message = "이름을 입력해주세요")
     String userName;
 
     @NotBlank(message = "비밀번호를 입력해주세요")
@@ -30,13 +32,16 @@ public class MemberDTO {
              message = "영문 대소문자와 숫자, 특수기호가 1개씩 포함되어있는 5~10자 비밀번호입니다")
     String password;
 
+    @NotBlank(message = "이메일을 입력해주세요")
     @Email
     String email;
 
+    @NotBlank(message = "전화번호를 입력해주세요")
     @Pattern(regexp = "(^02.{0}|^01.{1}|[0-9]{3})([0-9]{4})([0-9]{4})")
     String phoneNo;
 
     //정해진 값에 다른 값이 들어오는 것을 막기 위해 enum으로 관리
+    @NotNull
     UserLevel userLevel;
 
     String cityName;

--- a/src/main/java/com/festa/model/MemberLogin.java
+++ b/src/main/java/com/festa/model/MemberLogin.java
@@ -1,0 +1,23 @@
+package com.festa.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Value
+@Builder
+public class MemberLogin {
+
+    long userNo;
+
+    @NotBlank(message = "아이디를 입력해주세요")
+    String userId;
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{5,10}",
+            message = "영문 대소문자와 숫자, 특수기호가 1개씩 포함되어있는 5~10자 비밀번호입니다")
+    String password;
+
+}

--- a/src/main/java/com/festa/service/MemberService.java
+++ b/src/main/java/com/festa/service/MemberService.java
@@ -2,6 +2,7 @@ package com.festa.service;
 
 import com.festa.dao.MemberDAO;
 import com.festa.dto.MemberDTO;
+import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/festa/service/MemberService.java
+++ b/src/main/java/com/festa/service/MemberService.java
@@ -2,13 +2,14 @@ package com.festa.service;
 
 import com.festa.dao.MemberDAO;
 import com.festa.dto.MemberDTO;
-import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Log4j2
 @RequiredArgsConstructor
 public class MemberService {
 

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -89,22 +89,23 @@
 
     <select id="getUserByNo" resultType="com.festa.dto.MemberDTO">
         SELECT
+            M.userNo,
             M.userId,
             M.userName,
             M.password,
             M.email,
             M.phoneNo,
+            M.userLevel,
             MA.cityName,
             MA.districtName,
             MA.streetName,
-            M.userLevel,
             M.deleted,
             M.deletedDate
         FROM members M
         LEFT OUTER JOIN member_address MA
         ON M.userNo = MA.userNo
         WHERE M.userNo = #{userNo}
-        AND M.deleted = FALSE
+          AND M.deleted = FALSE
     </select>
 
     <update id="modifyMemberInfoForWithdraw" parameterType="com.festa.dto.MemberDTO">

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -55,35 +55,35 @@
 
     <update id="modifyMemberInfo" parameterType="com.festa.model.MemberInfo">
         UPDATE members
-            SET userName = #{username}
-            AND phoneNo  = #{phoneNo}
+            SET userName = #{userName},
+                phoneNo  = #{phoneNo}
         WHERE userNo = #{userNo};
     </update>
 
     <update id="modifyMemberAddress" parameterType="com.festa.model.MemberInfo">
         UPDATE member_address
-            SET cityName = #{cityName}
-            AND districtName = #{districtName}
-            AND streetName = #{streetName}
-            AND streetCode = #{streetCode}
+            SET cityName = #{cityName},
+                districtName = #{districtName},
+                streetName = #{streetName},
+                streetCode = #{streetCode}
         WHERE userNo = #{userNo}
     </update>
 
     <update id="modifyParticipantInfo" parameterType="com.festa.model.MemberInfo">
         UPDATE participant_address
-            SET cityName = #{cityName}
-            AND districtName = #{districtName}
-            AND streetName = #{streetName}
-            AND streetCode = #{streetCode}
-            AND detail = #{detail}
+            SET cityName = #{cityName},
+                districtName = #{districtName},
+                streetName = #{streetName},
+                streetCode = #{streetCode},
+                detail = #{detail}
         WHERE userNo = #{userNo}
             AND eventNo = #{eventNo}
     </update>
 
     <update id="changeUserPw" parameterType="com.festa.dto.MemberDTO">
         UPDATE members
-            SET password = #{password}
-            AND updatePwDate = NOW()
+            SET password = #{password},
+                updatePwDate = NOW()
         WHERE userNo = #{userNo}
     </update>
 
@@ -110,8 +110,8 @@
 
     <update id="modifyMemberInfoForWithdraw" parameterType="com.festa.dto.MemberDTO">
         UPDATE members
-            SET deleted = TRUE
-            AND deletedDate = NOW()
+            SET deleted = TRUE,
+                deletedDate = NOW()
         WHERE userNo = #{userNo};
     </update>
 


### PR DESCRIPTION
1. SQL에서 SELECT를 할 때 MemberDTO와 순서가 일치하지 않아 발생하는 오류 수정
    - `userNo` 를 조회해오지 않아 `userId` 가 long 형으로 형변환을 시도해서 오류가 발생
    - `userLevel` 의 순서가 잘못되어 `USERLEVEL.서울` 이런식으로 잘못된 데이터와 맵핑되어 오류 발생

<br>

2. 기타 조회나 insert 시 `@NotNull` validation에 걸려 동작하지 않는 문제 발생해 해당 어노테이션 제거
