### PR TITLE
회원정보 수정 기능 오류 수정

### DIFF
--- a/src/main/java/com/festa/common/SessionLogin.java
+++ b/src/main/java/com/festa/common/SessionLogin.java
@@ -2,6 +2,7 @@ package com.festa.common;
 
 import com.festa.common.commonService.LoginService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpSession;
@@ -13,6 +14,7 @@ import java.util.Optional;
  * 따로 인터페이스와 클래스로 분리시켜 둠.
  */
 
+@Log4j2
 @Component
 @RequiredArgsConstructor
 public class SessionLogin implements LoginService {

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -156,8 +156,8 @@ public class MemberController {
      */
     @CheckLoginStatus(auth = UserLevel.USER)
     @PatchMapping("/{userId}/password")
-    public ResponseEntity<HttpStatus> changePassword(@CurrentLoginUserNo long userNo, @RequestBody @Valid MemberDTO memberDTO) {
-        memberService.changeUserPw(userNo, memberDTO.getPassword());
+    public ResponseEntity<HttpStatus> changePassword(@CurrentLoginUserNo long userNo, @RequestBody MemberLogin memberLogin) {
+        memberService.changeUserPw(userNo, memberLogin.getPassword());
 
         return RESPONSE_ENTITY_OK;
     }

--- a/src/main/java/com/festa/service/MemberService.java
+++ b/src/main/java/com/festa/service/MemberService.java
@@ -2,13 +2,14 @@ package com.festa.service;
 
 import com.festa.dao.MemberDAO;
 import com.festa.dto.MemberDTO;
-import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Log4j2
 @RequiredArgsConstructor
 public class MemberService {
 

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -55,35 +55,35 @@
 
     <update id="modifyMemberInfo" parameterType="com.festa.model.MemberInfo">
         UPDATE members
-            SET userName = #{username}
-            AND phoneNo  = #{phoneNo}
+            SET userName = #{userName},
+                phoneNo  = #{phoneNo}
         WHERE userNo = #{userNo};
     </update>
 
     <update id="modifyMemberAddress" parameterType="com.festa.model.MemberInfo">
         UPDATE member_address
-            SET cityName = #{cityName}
-            AND districtName = #{districtName}
-            AND streetName = #{streetName}
-            AND streetCode = #{streetCode}
+            SET cityName = #{cityName},
+                districtName = #{districtName},
+                streetName = #{streetName},
+                streetCode = #{streetCode}
         WHERE userNo = #{userNo}
     </update>
 
     <update id="modifyParticipantInfo" parameterType="com.festa.model.MemberInfo">
         UPDATE participant_address
-            SET cityName = #{cityName}
-            AND districtName = #{districtName}
-            AND streetName = #{streetName}
-            AND streetCode = #{streetCode}
-            AND detail = #{detail}
+            SET cityName = #{cityName},
+                districtName = #{districtName},
+                streetName = #{streetName},
+                streetCode = #{streetCode},
+                detail = #{detail}
         WHERE userNo = #{userNo}
             AND eventNo = #{eventNo}
     </update>
 
     <update id="changeUserPw" parameterType="com.festa.dto.MemberDTO">
         UPDATE members
-            SET password = #{password}
-            AND updatePwDate = NOW()
+            SET password = #{password},
+                updatePwDate = NOW()
         WHERE userNo = #{userNo}
     </update>
 
@@ -110,8 +110,8 @@
 
     <update id="modifyMemberInfoForWithdraw" parameterType="com.festa.dto.MemberDTO">
         UPDATE members
-            SET deleted = TRUE
-            AND deletedDate = NOW()
+            SET deleted = TRUE,
+                deletedDate = NOW()
         WHERE userNo = #{userNo};
     </update>
 


### PR DESCRIPTION
1. UPDATE 쿼리문 전체 다 해당되는 내용, 바꿔야 할 것이 여러개일 경우 `AND`  예약어를 쓰면 동작상 오류가 발생됩니다. 그래서 모두 `,` 로 변경합니다!

2.  `modifyMemberInfo` SQL에서 `#{username}` 이 아니라 `#{userName}` 으로 카멜케이스가 적용이 안되어있어 오타 수정했습니다.