### PR TITLE
이벤트 조회기능 수정, 캐싱 적용 확인

### DIFF
--- a/src/main/java/com/festa/controller/EventController.java
+++ b/src/main/java/com/festa/controller/EventController.java
@@ -104,11 +104,12 @@ public class EventController {
     @PostMapping
     public ResponseEntity<HttpStatus> registerEvents(@RequestBody EventDTO eventDTO) {
         boolean isEventExists = eventService.isEventExists(eventDTO.getEventTitle(), eventDTO.getStartDate());
+        int categoryCode = eventDTO.getCategoryCode();
 
         if(isEventExists) {
             return RESPONSE_ENTITY_CONFLICT;
         }
-        eventService.registerEvents(eventDTO);
+        eventService.registerEvents(eventDTO, categoryCode);
 
         return RESPONSE_ENTITY_OK;
     }

--- a/src/main/java/com/festa/controller/EventController.java
+++ b/src/main/java/com/festa/controller/EventController.java
@@ -14,7 +14,15 @@ import com.festa.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -35,7 +43,7 @@ public class EventController {
     @GetMapping
     public Optional<List<EventDTO>> getListOfEvents(long cursorUserNo, int size, int categoryCode) {
 
-        return Optional.ofNullable(eventService.getListOfEvents(PageInfo.paging(cursorUserNo, size), categoryCode));
+        return Optional.ofNullable(eventService.getListOfEvents(new PageInfo(cursorUserNo, size), categoryCode));
     }
 
     /**

--- a/src/main/java/com/festa/dto/EventDTO.java
+++ b/src/main/java/com/festa/dto/EventDTO.java
@@ -1,53 +1,54 @@
 package com.festa.dto;
 
-import lombok.Builder;
-import lombok.Value;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import java.util.Date;
 
-@Value
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
 @Builder
 public class EventDTO {
 
-    long eventNo;
+    private long eventNo;
 
     long userNo;
 
     @NotBlank(message = "제목을 입력해주세요")
-    String eventTitle;
+    private String eventTitle;
 
     @NotBlank(message = "이벤트 내용을 입력해주세요")
-    String eventContent;
+    private String eventContent;
 
     @NotBlank(message = "이벤트 시작일 입력해주세요")
     @Pattern(regexp  = "^(19|20)\\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1])$",
              message = "연, 월, 일을 - 을 포함하여 입력해주세요")
-    String startDate;
+    private String startDate;
 
     @NotBlank(message = "이벤트 종료일 입력해주세요")
     @Pattern(regexp  = "^(19|20)\\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1])$",
             message = "연, 월, 일을 - 을 포함하여 입력해주세요")
-    String endDate;
+    private String endDate;
 
-    int categoryCode;
+    private int categoryCode;
 
-    int participantLimit;
+    private int participantLimit;
 
-    int noOfParticipants;
+    private int noOfParticipants;
 
-    Date registerDate;
+    private Date registerDate;
 
-    String cityName;
+    private String cityName;
 
-    String districtName;
+    private String districtName;
 
-    String streetCode;
+    private String streetCode;
 
-    String streetName;
+    private String streetName;
 
-    String detail;
+    private String detail;
 
     public EventDTO toEntityForInfo() {
 

--- a/src/main/java/com/festa/dto/EventDTO.java
+++ b/src/main/java/com/festa/dto/EventDTO.java
@@ -14,7 +14,7 @@ public class EventDTO {
 
     private long eventNo;
 
-    long userNo;
+    private long userNo;
 
     @NotBlank(message = "제목을 입력해주세요")
     private String eventTitle;

--- a/src/main/java/com/festa/service/EventService.java
+++ b/src/main/java/com/festa/service/EventService.java
@@ -7,6 +7,7 @@ import com.festa.model.PageInfo;
 import com.festa.model.Participants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +31,8 @@ public class EventService {
     }
 
     @Transactional
-    public void registerEvents(EventDTO eventDTO) {
+    @CacheEvict(key = "#categoryCode", value = CATEGORY_LIST, cacheManager = "redisCacheManager")
+    public void registerEvents(EventDTO eventDTO, int categoryCode) {
         EventDTO eventInfo = eventDTO.toEntityForInfo();
         eventDAO.registerEvents(eventInfo);
 

--- a/src/main/resources/mapper/EventsMapper.xml
+++ b/src/main/resources/mapper/EventsMapper.xml
@@ -22,14 +22,16 @@
 
     <select id="getListOfEvents" resultType="com.festa.dto.EventDTO">
         SELECT
+            A.userNo,
+            A.eventNo,
             A.eventTitle,
             A.eventContent,
             A.startDate,
             A.endDate,
-            A.registerDate,
+            A.categoryCode,
             A.participantLimit,
             A.noOfParticipants,
-            B.categoryName,
+            B.registerDate,
             B.cityName,
             B.districtName,
             B.streetName,
@@ -44,28 +46,29 @@
                 E.eventContent,
                 E.startDate,
                 E.endDate,
-                E.registerDate,
+                E.categoryCode,
                 E.participantLimit,
                 E.noOfParticipants,
-                C.categoryName,
+                E.registerDate,
                 EA.cityName,
                 EA.districtName,
+                EA.streetCode,
                 EA.streetName,
                 EA.detail,
                 M.userName AS writer
-             FROM events E
-              LEFT OUTER JOIN event_address EA
-              ON EA.eventNo = E.eventNo
-              LEFT OUTER JOIN category C
-              ON C.categoryCode = E.categoryCode
-              INNER JOIN members M
-              ON E.userNo = M.userNo
-             WHERE E.userNo <![CDATA[<]]> #{PageInfo.cursorUserNo}
-             <if test=" categoryCode != null and categoryCode != '' ">
-                 AND E.categoryCode = #{categotyCode}
-             </if>
-             ORDER BY registerDate DESC
-             LIMIT #{PageInfo.size}
+            FROM events E
+            LEFT OUTER JOIN event_address EA
+            ON EA.eventNo = E.eventNo
+            LEFT OUTER JOIN category C
+            ON C.categoryCode = E.categoryCode
+            INNER JOIN members M
+            ON E.userNo = M.userNo
+            WHERE E.userNo <![CDATA[<]]> #{pageInfo.cursorUserNo}
+            <if test=" categoryCode != 0 ">
+                AND E.categoryCode = #{categoryCode}
+            </if>
+            ORDER BY registerDate DESC
+            LIMIT #{pageInfo.size}
             ) AS B
         WHERE A.eventNo = B.eventNo
     </select>

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -101,6 +101,7 @@
             M.userLevel,
             MA.cityName,
             MA.districtName,
+            MA.streetCode,
             MA.streetName,
             M.deleted,
             M.deletedDate


### PR DESCRIPTION
1. `getListOfEvents` SQL에서 `pageInfo` 의 p를 대문자로 써서 맵핑오류 수정
2. `#{categoryList}` 오타 수정
3. 캐싱적용 전 조회속도 `189ms` -> 캐싱적용 후 `12ms` 로 속도 향상 
4. 캐시 히트율 계산: 180초로 설정했을 때 캐시히트율 **0.87** 로 계산되었습니다! (0.8 이상이 적절한 수치를 의미합니다)
5. 캐시 된 데이터를 Redis 에서 `deserializer` 할 때 `EventDTO` 의 생성자 문제로 `@Value` 어노테이션을 제거하고 `@AllArgsConstructor`, `@NoArgsConstructor`, `@Getter`, `@Builder` 로 변경했습니다.