### PR TITLE
이벤트 변경알림 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# FESTA! 
+# :ferris_wheel: FESTA! :ferris_wheel:
 
 사용자가 설정한 지역의 이벤트와 행사를 추천해주는 서비스 입니다.    
 백엔드 로직에 집중하기 위해서 화면은 프로토타입으로 설계하였으며 
 REST API 서버로 대용량 트래픽을 고려한 애플리케이션으로 개발하였습니다. 
-화면 디자인이나 Usecase는 WIKI에서 확인이 가능합니다.
+화면 디자인이나 Usecase는 [WIKI](https://github.com/f-lab-edu/event-recommender-festa/wiki) 에서 확인이 가능합니다.
+
+
 
 <br>
 <br>
 
-## 프로젝트 사용기술 
+##  :rocket: 프로젝트 사용기술 
 - [Spring Boot](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle)
 - [Java 8](https://docs.oracle.com/javase/8/docs/api/)
 - [MySQL](https://dev.mysql.com/doc/refman/8.0/en/)
@@ -16,29 +18,35 @@ REST API 서버로 대용량 트래픽을 고려한 애플리케이션으로 개
 - [Maven](http://maven.apache.org/guides/index.html)
 - [Redis](https://redis.io/documentation)
 - [Naver cloud platform](https://docs.ncloud.com/ko/)
+- [AWS S3](https://docs.aws.amazon.com/index.html?nc2=h_ql_doc_do_v)
+- [Firebase](https://firebase.google.com/docs)
 - intellij IDEA
 
 <br>
 <br>
 
-## 전체 프로젝트의 구조
+##  :rocket: 전체 프로젝트의 구조
+
+![image](https://user-images.githubusercontent.com/58355531/109328559-e8bf1400-789c-11eb-8a47-5db63e8d2c3d.png)
 
 <br>
 <br>
 
 
-## 프로젝트 주요 관심사
+##  :rocket: 프로젝트 주요 관심사
 
-- 대용량 트래픽의 상황에서 지속적인 서버 성능 개선
-- 클린코드를 위한 꾸준한 코드 리팩토링 
-- 이유와 근거가 명확한 기술의 사용
-- 객체지향적 개념을 이해하고 이를 코드에 녹여내어 의미있는 설계를 지향
+:heavy_check_mark: 대용량 트래픽의 상황에서 지속적인 서버 성능을 개선하기 위해 노력하였습니다.    
+:heavy_check_mark: 클린코드를 위한 꾸준한 코드 리팩토링을 진행 중입니다.      
+:heavy_check_mark: 이유와 근거가 명확한 기술의 사용을 지향합니다.    
+:heavy_check_mark: 객체지향적 개념을 이해하고 이를 코드에 녹여내어 의미있는 설계를 지향하였습니다.    
+:heavy_check_mark: 성공만 하는 테스트 보단 실패할 만한 단위 테스트를 작성하였습니다.    
+:heavy_check_mark: 반복적인 작업은 자동화하여 개발의 효율을 높이기 위해 노력하였습니다.      
 
 <br>
 <br>
 
 
-### Git-Flow 브랜치 전략
+### :diamond_shape_with_a_dot_inside: Git-Flow 브랜치 전략
 
 **Git-Flow 브랜치 전략**에 따라 기능별로 브랜치를 나누어 작업하고 있고 
 모든 브랜치에 대해 pull request를 통한 리뷰 완료 후 Merge를 하고 있습니다.
@@ -51,11 +59,11 @@ REST API 서버로 대용량 트래픽을 고려한 애플리케이션으로 개
 <br>
 <br>
 
-- master : 제품으로 출시될 수 있는 브랜치를 의미합니다. 
-- develop : 다음 출시 버전을 개발하는 브랜치입니다. feature에서 리뷰완료한 브랜치를 Merge하고 있습니다.
-- feature : 기능을 개발하는 브랜치
-- release : 이번 출시 버전을 준비하는 브랜치
-- hotfix : 출시 버전에서 발생한 버그를 수정하는 브랜치
+:white_check_mark: master : 제품으로 출시될 수 있는 브랜치를 의미합니다.     
+:white_check_mark: develop : 다음 출시 버전을 개발하는 브랜치입니다. feature에서 리뷰완료한 브랜치를 Merge하고 있습니다.    
+:white_check_mark: feature : 기능을 개발하는 브랜치    
+:white_check_mark: release : 이번 출시 버전을 준비하는 브랜치    
+:white_check_mark: hotfix : 출시 버전에서 발생한 버그를 수정하는 브랜치    
 
 <br>
 
@@ -66,20 +74,30 @@ REST API 서버로 대용량 트래픽을 고려한 애플리케이션으로 개
 <br>
 <br>
 
-## WIKI
+### :diamond_shape_with_a_dot_inside: Jenkins CI/CD
+
+빌드와 테스트를 자동화 하여 개발 효율성을 높일 수 있도록 젠킨스를 활용하였습니다. 
+아래의 주소를 통해 젠킨스 status 확인이 가능합니다.
+
+:heavy_check_mark: 젠킨스 주소 바로가기 : <http://27.96.135.160:8081/>
+
+<br>
+<br>
+
+##  :rocket: WIKI
 
 화면설계에 대한 **kakao oven** 프로토타입 디자인과 Usecase를 보실 수 있습니다.
-또한, 기술적인 문제에 부딪혀 해결한 이야기에 대한 개인 테크블로그의 주소도 포함되어있습니다.
+API에 대한 상세하게 설명해두었으며 기술적인 문제에 부딪혀 해결한 이야기에 대한 개인 테크블로그의 주소도 포함되어있습니다.
 
  - [Usecase](https://github.com/f-lab-edu/event-recommender-festa/wiki/Usecase)
  - [WIKI Home](https://github.com/f-lab-edu/event-recommender-festa/wiki)
  - [이슈해결을 정리한 테크블로그](https://github.com/f-lab-edu/event-recommender-festa/wiki/%EC%9D%B4%EC%8A%88%ED%95%B4%EA%B2%B0Posts)
- - [젠킨스 주소 바로가기](http://27.96.135.160:8081/)
+ - [API 상세스펙](https://github.com/f-lab-edu/event-recommender-festa/wiki#%EC%83%81%EC%84%B8-api-%EC%8A%A4%ED%8E%99-%EB%B0%94%EB%A1%9C%EA%B0%80%EA%B8%B0)
  
 <br>
 <br>
 
-## 화면 구성도
+##  :rocket: 화면 구성도
 
 ![사용자화면구성도 (1)](https://user-images.githubusercontent.com/58355531/93668916-f5a83200-faca-11ea-87ac-e72e55daffa5.png)
 
@@ -93,7 +111,7 @@ ___
 <br>
 <br>
 
-## DB ERD 구조
+##  :rocket: DB ERD 구조
 
 ![event-recommender-festa-erd](https://user-images.githubusercontent.com/53729311/104211019-e896c080-5476-11eb-8dbc-183656873e5e.jpg)
 

--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ API에 대한 상세하게 설명해두었으며 기술적인 문제에 부딪�
 
 ##  :rocket: 화면 구성도
 
-![사용자화면구성도 (1)](https://user-images.githubusercontent.com/58355531/93668916-f5a83200-faca-11ea-87ac-e72e55daffa5.png)
+![image](https://user-images.githubusercontent.com/58355531/109332890-15c1f580-78a2-11eb-9596-eadf94a1ac10.png)
 
 <br>
 
 ___
 
 
-![주최자화면구성도](https://user-images.githubusercontent.com/58355531/93669060-2472d800-facc-11ea-977d-fc679c0519f0.png)
+![image](https://user-images.githubusercontent.com/58355531/109332798-f6c36380-78a1-11eb-9283-92796a76ade2.png)
 
 <br>
 <br>

--- a/src/main/java/com/festa/controller/EventController.java
+++ b/src/main/java/com/festa/controller/EventController.java
@@ -141,7 +141,7 @@ public class EventController {
     public List<AlertResponse> modifyEventsInfo(@RequestBody EventDTO eventDTO) {
         eventService.modifyEventsInfo(eventDTO);
 
-        List<AlertResponse> sendModifyAlert = alertService.eventModifyNotice(eventDTO.getEventNo());
+        List<AlertResponse> sendModifyAlert = alertService.getParticipantsNeedAlert(eventDTO.getEventNo());
 
         return sendModifyAlert;
     }

--- a/src/main/java/com/festa/controller/EventController.java
+++ b/src/main/java/com/festa/controller/EventController.java
@@ -8,8 +8,10 @@ import com.festa.aop.CheckLoginStatus;
 import com.festa.common.UserLevel;
 import com.festa.common.commonService.CurrentLoginUserNo;
 import com.festa.dto.EventDTO;
+import com.festa.model.AlertResponse;
 import com.festa.model.PageInfo;
 import com.festa.model.Participants;
+import com.festa.service.AlertService;
 import com.festa.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -34,6 +36,7 @@ import java.util.Optional;
 public class EventController {
 
     private final EventService eventService;
+    private final AlertService alertService;
 
     /**
      * 리스트형 이벤트 목록 조회 기능
@@ -116,20 +119,16 @@ public class EventController {
 
     /**
      * 주최자 이벤트 참여자 목록 조회 기능
-     * @param participants
+     * @param userNo, eventNo
      * @return {@literal ResponseEntity<HttpStatus>}
      * @throws NoSuchElementException (조회된 데이터가 없을 경우)
      */
     @CheckLoginStatus(auth = UserLevel.HOST)
     @GetMapping("/{eventNo}/participants")
-    public ResponseEntity<HttpStatus> getParticipantList(@CurrentLoginUserNo long userNo, @RequestBody Participants participants) {
-        Participants participantsList = eventService.getParticipantList(userNo, participants);
+    public List<Participants> getParticipantList(@CurrentLoginUserNo long userNo, long eventNo) {
+        List<Participants> participantsList = eventService.getParticipantList(userNo, eventNo);
 
-        if(participantsList == null) {
-            throw new NoSuchElementException("현재 참여자가 없습니다.");
-        }
-
-        return RESPONSE_ENTITY_OK;
+        return participantsList;
     }
 
     /**
@@ -139,10 +138,12 @@ public class EventController {
      */
     @CheckLoginStatus(auth = UserLevel.HOST)
     @PutMapping("/{eventNo}")
-    public ResponseEntity<HttpStatus> modifyEventsInfo(@RequestBody EventDTO eventDTO) {
+    public List<AlertResponse> modifyEventsInfo(@RequestBody EventDTO eventDTO) {
         eventService.modifyEventsInfo(eventDTO);
 
-        return RESPONSE_ENTITY_OK;
+        List<AlertResponse> sendModifyAlert = alertService.sendEventModifyNotice(eventDTO.getEventNo());
+
+        return sendModifyAlert;
     }
 
     /**

--- a/src/main/java/com/festa/controller/EventController.java
+++ b/src/main/java/com/festa/controller/EventController.java
@@ -141,7 +141,7 @@ public class EventController {
     public List<AlertResponse> modifyEventsInfo(@RequestBody EventDTO eventDTO) {
         eventService.modifyEventsInfo(eventDTO);
 
-        List<AlertResponse> sendModifyAlert = alertService.sendEventModifyNotice(eventDTO.getEventNo());
+        List<AlertResponse> sendModifyAlert = alertService.eventModifyNotice(eventDTO.getEventNo());
 
         return sendModifyAlert;
     }

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -135,8 +135,8 @@ public class MemberController {
 
         firebaseTokenManager.makeAccessToken(memberLogin.getUserNo());
 
-        List<AlertResponse> loginResponses = alertService.sendEventStartNotice(memberLogin.getUserNo(), LocalDate.now());
-        AlertResponse isUserNeedToChangePw = alertService.getChangePwDateDiff(memberLogin.getUserNo());
+        List<AlertResponse> loginResponses = alertService.eventStartNotice(memberLogin.getUserNo(), LocalDate.now());
+        AlertResponse isUserNeedToChangePw = alertService.changePasswordNotice(memberLogin.getUserNo());
 
         loginResponses.add(isUserNeedToChangePw);
 

--- a/src/main/java/com/festa/dao/EventDAO.java
+++ b/src/main/java/com/festa/dao/EventDAO.java
@@ -42,7 +42,7 @@ public interface EventDAO {
 
     boolean isParticipated(long userNo);
 
-    Participants getParticipantList(Participants participants);
+    List<Participants> getParticipantList(long eventNo);
 
     void deleteEvent(long eventNo);
 

--- a/src/main/java/com/festa/dto/EventDTO.java
+++ b/src/main/java/com/festa/dto/EventDTO.java
@@ -54,6 +54,7 @@ public class EventDTO {
 
         return EventDTO.builder()
                 .userNo(this.userNo)
+                .eventNo(this.eventNo)
                 .eventTitle(this.eventTitle)
                 .eventContent(this.eventContent)
                 .startDate(this.startDate)

--- a/src/main/java/com/festa/service/AlertService.java
+++ b/src/main/java/com/festa/service/AlertService.java
@@ -10,7 +10,6 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.WebpushConfig;
 import com.google.firebase.messaging.WebpushNotification;
-import javafx.scene.control.Alert;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/festa/service/AlertService.java
+++ b/src/main/java/com/festa/service/AlertService.java
@@ -49,7 +49,7 @@ public class AlertService {
 
     }
 
-    public List<AlertResponse> sendEventStartNotice(long userNo, LocalDate todayDate) {
+    public List<AlertResponse> eventStartNotice(long userNo, LocalDate todayDate) {
 
         List<AlertResponse> response = new LinkedList<>();
         List<Long> appliedEvents = eventDAO.getAppliedEvent(userNo);
@@ -80,7 +80,7 @@ public class AlertService {
         return response;
     }
 
-    public List<AlertResponse> sendEventModifyNotice(long eventNo) {
+    public List<AlertResponse> eventModifyNotice(long eventNo) {
         List<AlertResponse> response = new LinkedList<>();
         List<Participants> participants = eventDAO.getParticipantList(eventNo);
 
@@ -99,7 +99,7 @@ public class AlertService {
         return response;
     }
 
-    public AlertResponse getChangePwDateDiff(long userNo) {
+    public AlertResponse changePasswordNotice(long userNo) {
 
         return AlertResponse.builder()
                 .alertType("sendChangePwToUser")

--- a/src/main/java/com/festa/service/AlertService.java
+++ b/src/main/java/com/festa/service/AlertService.java
@@ -17,6 +17,7 @@ import java.time.LocalDate;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -83,10 +84,12 @@ public class AlertService {
         List<AlertResponse> response = new LinkedList<>();
         List<Participants> participants = eventDAO.getParticipantList(eventNo);
 
-        participants.forEach(participantsInfo -> {
+        Stream<Long> userNo = participants.stream().map(Participants::getUserNo);
+
+        userNo.forEach(participantsUserNo -> {
             AlertResponse sendAlert = AlertResponse.builder()
                     .alertType("eventModifyAlertToParticipants")
-                    .targetNo(participantsInfo.getUserNo())
+                    .targetNo(participantsUserNo)
                     .isAlertNeed(true)
                     .build();
 

--- a/src/main/java/com/festa/service/AlertService.java
+++ b/src/main/java/com/festa/service/AlertService.java
@@ -5,10 +5,12 @@ import com.festa.dao.EventDAO;
 import com.festa.dao.MemberDAO;
 import com.festa.dto.EventDTO;
 import com.festa.model.AlertResponse;
+import com.festa.model.Participants;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.WebpushConfig;
 import com.google.firebase.messaging.WebpushNotification;
+import javafx.scene.control.Alert;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -73,6 +75,23 @@ public class AlertService {
 
                 response.add(notSendAlert);
             }
+        });
+
+        return response;
+    }
+
+    public List<AlertResponse> sendEventModifyNotice(long eventNo) {
+        List<AlertResponse> response = new LinkedList<>();
+        List<Participants> participants = eventDAO.getParticipantList(eventNo);
+
+        participants.forEach(participantsInfo -> {
+            AlertResponse sendAlert = AlertResponse.builder()
+                    .alertType("eventModifyAlertToParticipants")
+                    .targetNo(participantsInfo.getUserNo())
+                    .isAlertNeed(true)
+                    .build();
+
+            response.add(sendAlert);
         });
 
         return response;

--- a/src/main/java/com/festa/service/AlertService.java
+++ b/src/main/java/com/festa/service/AlertService.java
@@ -80,7 +80,7 @@ public class AlertService {
         return response;
     }
 
-    public List<AlertResponse> eventModifyNotice(long eventNo) {
+    public List<AlertResponse> getParticipantsNeedAlert(long eventNo) {
         List<AlertResponse> response = new LinkedList<>();
         List<Participants> participants = eventDAO.getParticipantList(eventNo);
 

--- a/src/main/java/com/festa/service/EventService.java
+++ b/src/main/java/com/festa/service/EventService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @Log4j2
@@ -90,13 +91,20 @@ public class EventService {
         eventDAO.reduceParticipants(participants.getEventNo());
     }
 
-    public Participants getParticipantList(long userNo, Participants participants) {
+    public List<Participants> getParticipantList(long userNo, long eventNo) {
+        EventDTO eventInfo = eventDAO.getInfoOfEvent(eventNo);
 
-        if(userNo != participants.getUserNo()) {
+        if(userNo != eventInfo.getUserNo()) {
             throw new IllegalStateException("이벤트를 등록한 주최자만 조회가 가능합니다.");
         }
 
-        return eventDAO.getParticipantList(participants);
+        List<Participants> participantsList = eventDAO.getParticipantList(eventNo);
+
+        if(participantsList.size() == 0) {
+            throw new NoSuchElementException("현재 참여자가 없습니다.");
+        }
+
+        return participantsList;
     }
 
     @Transactional

--- a/src/main/resources/mapper/EventsMapper.xml
+++ b/src/main/resources/mapper/EventsMapper.xml
@@ -109,7 +109,7 @@
         WHERE userNo = #{userNo}
     </select>
 
-    <select id="getParticipantList" parameterType="com.festa.model.Participants">
+    <select id="getParticipantList" resultType="com.festa.model.Participants">
         SELECT
             P.eventNo,
             P.userNo,
@@ -223,18 +223,18 @@
 
     <update id="modifyEventsInfo" parameterType="com.festa.dto.EventDTO">
         UPDATE events
-            SET eventTitle = #{eventTitle}
-            AND eventContent = #{eventContent}
+            SET eventTitle = #{eventTitle},
+                eventContent = #{eventContent}
         WHERE eventNo = #{eventNo}
     </update>
 
     <update id="modifyEventsAddress" parameterType="com.festa.dto.EventDTO">
         UPDATE event_address
-            SET cityName = #{cityName}
-            AND districtName = #{districtName}
-            AND streetCode = #{streetCode}
-            AND streetName = #{streetName}
-            AND detail = #{detail}
+            SET cityName = #{cityName},
+                districtName = #{districtName},
+                streetCode = #{streetCode},
+                streetName = #{streetName},
+                detail = #{detail}
         WHERE eventNo = #{eventNo}
     </update>
 


### PR DESCRIPTION
이벤트 변경 알림 기능을 추가하면서 해당 이벤트의 참여자 목록을 불러와야 했었는데 연결하는 과정에서 **이벤트 참여자 목록조회** 기능의 로직 변경의 필요가 있었습니다.

<br>

### 변경 사항 EventController - getParticipantsList
1. 이벤트 참여자 목록조회 `getParticipantsList` 의 리턴값이 원래 `Participants` 였으나 참여자가 여러명이기 때문에 `List<Participants>` 로 변경하였습니다.   

2. 이벤트 참여자 목록조회 `getParticipantsList` 의 파라미터는 원래 `userNo` 와 `Participants` 였으나 `Participants` 를 삭제하고 `eventNo` 만 받을 수 있도록 변경하였습니다.

### 변경사항 EventService - getParticipantsList
1. 로그인한 회원의 회원번호(`userNo`)와 파라미터로 받은 `eventNo` 의 상세정보를 조회하여 로그인한 회원이 해당 이벤트 게시글을 작성했는지 유효성 체크를 추가하여 작성한 게시글이 아닐 시 `이벤트를 등록한 주최자만 조회가 가능합니다.` 라는 예외메시지를 출력하도록 변경했습니다.

2. 해당 게시글을 작성한 회원일 때 이벤트 참여자 목록조회를 하여 참여자가 없다면 `현재 참여자가 없습니다.` 라는 예외메시지를 출력하도록 하였습니다.

### 변경사항 EventMapper.xml
1. `getParticipantsList` 의 parameterType 이 아닌 **resultType** 으로 수정하였습니다.
2. `modifyEventsInfo` , `modifyEventsAddress` 에서 `SET` 다음 `AND` 가 아닌 `콤마` 로 수정하였습니다.

### 응답
![image](https://user-images.githubusercontent.com/58355531/109012203-179a8600-76f5-11eb-9ef2-e27defa606ce.png)

> 참여자가 없을 시 응답은 빈 값으로 리턴합니다.

#### 작업에 참고바랍니다~!