### PR TITLE
controller의 리턴타입 수정

### DIFF
--- a/src/main/java/com/festa/controller/EventController.java
+++ b/src/main/java/com/festa/controller/EventController.java
@@ -153,9 +153,7 @@ public class EventController {
      */
     @CheckLoginStatus(auth = UserLevel.HOST)
     @DeleteMapping("/{eventNo}")
-    public ResponseEntity<HttpStatus> deleteEvent(long eventNo, @CurrentLoginUserNo long userNo) {
+    public void deleteEvent(long eventNo, @CurrentLoginUserNo long userNo) {
         eventService.deleteEventNo(eventNo, userNo);
-
-        return RESPONSE_ENTITY_OK;
     }
 }

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -93,7 +93,7 @@ public class MemberController {
      */
     @CheckLoginStatus(auth = UserLevel.USER)
     @PutMapping("/{userNo}")
-    public ResponseEntity<HttpStatus> modifyMemberInfo(@RequestBody MemberInfo memberInfo) {
+    public void modifyMemberInfo(@RequestBody MemberInfo memberInfo) {
         boolean isUserModifyInfo = memberInfo.isUserModifyInfo();
 
         if(isUserModifyInfo) {
@@ -103,8 +103,6 @@ public class MemberController {
         } else {
             memberService.modifyParticipantInfo(memberInfo);
         }
-
-        return RESPONSE_ENTITY_OK;
     }
 
     /**
@@ -113,10 +111,8 @@ public class MemberController {
      * @return {@literal ResponseEntity<HttpStatus>}
      */
     @GetMapping("/{userId}/delete")
-    public ResponseEntity<HttpStatus> isIdDeleted(@RequestParam String userId, @RequestParam String password) {
+    public void isIdDeleted(@RequestParam String userId, @RequestParam String password) {
         memberService.isUserIdExist(userId, password);
-
-        return RESPONSE_ENTITY_OK;
     }
 
     /**
@@ -151,13 +147,11 @@ public class MemberController {
      */
     @CheckLoginStatus(auth = UserLevel.USER)
     @PostMapping("/logout")
-    public ResponseEntity<HttpStatus> logout(@CurrentLoginUserNo long userNo) {
+    public void logout(@CurrentLoginUserNo long userNo) {
         loginService.removeUserNo();
 
         String string_userNo = ConvertDataType.longToString(userNo);
         firebaseTokenManager.removeToken(string_userNo);
-
-        return RESPONSE_ENTITY_OK;
     }
 
     /**
@@ -167,10 +161,8 @@ public class MemberController {
      */
     @CheckLoginStatus(auth = UserLevel.USER)
     @PatchMapping("/{userId}/password")
-    public ResponseEntity<HttpStatus> changePassword(@CurrentLoginUserNo long userNo, @RequestBody MemberLogin memberLogin) {
+    public void changePassword(@CurrentLoginUserNo long userNo, @RequestBody MemberLogin memberLogin) {
         memberService.changeUserPw(userNo, memberLogin.getPassword());
-
-        return RESPONSE_ENTITY_OK;
     }
 
     /**
@@ -180,9 +172,7 @@ public class MemberController {
      */
     @CheckLoginStatus(auth = UserLevel.USER)
     @DeleteMapping("/")
-    public ResponseEntity<HttpStatus> memberWithdraw(@CurrentLoginUserNo long userNo, String password) {
+    public void memberWithdraw(@CurrentLoginUserNo long userNo, String password) {
         memberService.memberWithdraw(userNo);
-        
-        return RESPONSE_ENTITY_OK;
     }
 }


### PR DESCRIPTION
컨트롤러들에서 리턴타입이 ResponseEntity인 메서드들 중 ResponseEntity<HttpStatus.OK>만 리턴하는 메서드들이 있습니다.

리턴타입을 void로 설정할 경우 자동으로 매핑되어있는 url과 같은 이름의 뷰를 실행하기 때문에 ResponseEntity<HttpStatus.OK>와 같은 결과를 보입니다.

그래서 컨트롤러에서 해당 메서드들의 리턴타입을 void로 수정하였습니다.