### PR TITLE
RedisConfig session, cache 분리 재설정

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,11 +11,14 @@ spring.datasource.hikari.slave.jdbc-url=jdbc:mysql://localhost:3306/festa?autoRe
 spring.datasource.hikari.slave.username=root
 spring.datasource.hikari.slave.password=ENC(DTciqdzLK2NoVHRNEwtydw==)
 
-# Redis connection
+# Redis session connection
 spring.session.store-type=redis
-spring.cache.type=redis
 spring.redis.host=localhost
-spring.redis.port=6379
+spring.redis.session.port=6378
+
+# Redis cache connection
+spring.cache.type=redis
+spring.redis.cache.port=6379
 
 # Firebase Database Name
 firebase.database.url=https://festa-42bbe.firebaseio.com


### PR DESCRIPTION
컴퓨터 교체로 환경설정을 다시해보다 잘못설정한 부분이있어 수정했습니다 :) 

- redis session: 6378포트
- redis cache: 6379포트 (도커 이용중입니다)