### PR TITLE
로그인 구조 개선 작업

### DIFF
--- a/src/main/java/com/festa/common/SessionLoginService.java
+++ b/src/main/java/com/festa/common/SessionLoginService.java
@@ -3,6 +3,7 @@ package com.festa.common;
 import com.festa.common.commonService.LoginService;
 import com.festa.common.firebase.FirebaseTokenManager;
 import com.festa.service.AlertService;
+import com.festa.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
@@ -25,6 +26,7 @@ public class SessionLoginService implements LoginService {
     public static final String USER_NO = "userNo";
     public final HttpSession httpSession;
     private final FirebaseTokenManager firebaseTokenManager;
+    private final MemberService memberService;
     private final AlertService alertService;
 
     /**
@@ -32,7 +34,8 @@ public class SessionLoginService implements LoginService {
      * @param userNo
      */
     @Override
-    public void login(Long userNo, String token) {
+    public void login(Long userNo, String userId, String password, String token) {
+        memberService.isUserIdExist(userId, password);
         httpSession.setAttribute(USER_NO, userNo);
         firebaseLoginAlert(userNo, token);
     }

--- a/src/main/java/com/festa/common/SessionLoginService.java
+++ b/src/main/java/com/festa/common/SessionLoginService.java
@@ -2,7 +2,6 @@ package com.festa.common;
 
 import com.festa.common.commonService.LoginService;
 import com.festa.common.firebase.FirebaseTokenManager;
-import com.festa.common.util.ConvertDataType;
 import com.festa.service.AlertService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -46,9 +45,7 @@ public class SessionLoginService implements LoginService {
     @Override
     public void logout(long userNo) {
         httpSession.removeAttribute(USER_NO);
-
-        String string_userNo = ConvertDataType.longToString(userNo);
-        firebaseTokenManager.removeToken(string_userNo);
+        firebaseTokenManager.removeToken(String.valueOf(userNo));
     }
 
     /**

--- a/src/main/java/com/festa/common/SessionLoginService.java
+++ b/src/main/java/com/festa/common/SessionLoginService.java
@@ -2,6 +2,7 @@ package com.festa.common;
 
 import com.festa.common.commonService.LoginService;
 import com.festa.common.firebase.FirebaseTokenManager;
+import com.festa.common.util.ConvertDataType;
 import com.festa.service.AlertService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -83,5 +84,15 @@ public class SessionLoginService implements LoginService {
         firebaseTokenManager.register(String.valueOf(userNo), token);
         alertService.eventStartNotice(userNo, LocalDate.now());
         alertService.changePasswordNotice(userNo);
+    }
+
+    /**
+     * 로그아웃 시 firebase Token 삭제
+     * @param userNo
+     */
+    @Override
+    public void removeToken(long userNo) {
+        String string_userNo = ConvertDataType.longToString(userNo);
+        firebaseTokenManager.removeToken(string_userNo);
     }
 }

--- a/src/main/java/com/festa/common/SessionLoginService.java
+++ b/src/main/java/com/festa/common/SessionLoginService.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 @Log4j2
 @Component
 @RequiredArgsConstructor
-public class SessionLogin implements LoginService {
+public class SessionLoginService implements LoginService {
 
     public static final String USER_NO = "userNo";
     public final HttpSession httpSession;

--- a/src/main/java/com/festa/common/SessionLoginService.java
+++ b/src/main/java/com/festa/common/SessionLoginService.java
@@ -29,12 +29,13 @@ public class SessionLoginService implements LoginService {
     private final AlertService alertService;
 
     /**
-     * 세션에 userNo 저장하는 메서드
+     * 세션에 userNo 저장하고 Firebase 알림여부 전송 메서드 호출
      * @param userNo
      */
     @Override
-    public void setUserNo(Long userNo) {
+    public void login(Long userNo, String token) {
         httpSession.setAttribute(USER_NO, userNo);
+        firebaseLoginAlert(userNo, token);
     }
 
     /**
@@ -82,8 +83,7 @@ public class SessionLoginService implements LoginService {
      * @param userNo
      * @param token
      */
-    @Override
-    public void successLogin(long userNo, String token) {
+    private void firebaseLoginAlert(long userNo, String token) {
         firebaseTokenManager.register(String.valueOf(userNo), token);
         alertService.eventStartNotice(userNo, LocalDate.now());
         alertService.changePasswordNotice(userNo);

--- a/src/main/java/com/festa/common/SessionLoginService.java
+++ b/src/main/java/com/festa/common/SessionLoginService.java
@@ -1,11 +1,14 @@
 package com.festa.common;
 
 import com.festa.common.commonService.LoginService;
+import com.festa.common.firebase.FirebaseTokenManager;
+import com.festa.service.AlertService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpSession;
+import java.time.LocalDate;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -21,6 +24,8 @@ public class SessionLoginService implements LoginService {
 
     public static final String USER_NO = "userNo";
     public final HttpSession httpSession;
+    private final FirebaseTokenManager firebaseTokenManager;
+    private final AlertService alertService;
 
     /**
      * 세션에 userNo 저장하는 메서드
@@ -66,5 +71,17 @@ public class SessionLoginService implements LoginService {
                 .map(no -> (Long) no);
 
         return userNo.orElseThrow(NoSuchElementException::new);
+    }
+
+    /**
+     * 로그인 후 firebase token 저장 및 알림전송의 비즈니스 로직 처리
+     * @param userNo
+     * @param token
+     */
+    @Override
+    public void afterLogin(long userNo, String token) {
+        firebaseTokenManager.register(String.valueOf(userNo), token);
+        alertService.eventStartNotice(userNo, LocalDate.now());
+        alertService.changePasswordNotice(userNo);
     }
 }

--- a/src/main/java/com/festa/common/SessionLoginService.java
+++ b/src/main/java/com/festa/common/SessionLoginService.java
@@ -38,13 +38,16 @@ public class SessionLoginService implements LoginService {
     }
 
     /**
-     * 세션에 userNo를 제거하는 메서드
+     * 로그아웃 시 세션의 userNo 제거, firebase Token 삭제
      * No Param
      * No return
      */
     @Override
-    public void removeUserNo() {
+    public void logout(long userNo) {
         httpSession.removeAttribute(USER_NO);
+
+        String string_userNo = ConvertDataType.longToString(userNo);
+        firebaseTokenManager.removeToken(string_userNo);
     }
 
     /**
@@ -84,15 +87,5 @@ public class SessionLoginService implements LoginService {
         firebaseTokenManager.register(String.valueOf(userNo), token);
         alertService.eventStartNotice(userNo, LocalDate.now());
         alertService.changePasswordNotice(userNo);
-    }
-
-    /**
-     * 로그아웃 시 firebase Token 삭제
-     * @param userNo
-     */
-    @Override
-    public void removeToken(long userNo) {
-        String string_userNo = ConvertDataType.longToString(userNo);
-        firebaseTokenManager.removeToken(string_userNo);
     }
 }

--- a/src/main/java/com/festa/common/SessionLoginService.java
+++ b/src/main/java/com/festa/common/SessionLoginService.java
@@ -83,7 +83,7 @@ public class SessionLoginService implements LoginService {
      * @param token
      */
     @Override
-    public void afterLogin(long userNo, String token) {
+    public void successLogin(long userNo, String token) {
         firebaseTokenManager.register(String.valueOf(userNo), token);
         alertService.eventStartNotice(userNo, LocalDate.now());
         alertService.changePasswordNotice(userNo);

--- a/src/main/java/com/festa/common/commonService/LoginService.java
+++ b/src/main/java/com/festa/common/commonService/LoginService.java
@@ -18,4 +18,6 @@ public interface LoginService {
     boolean isLoginUser();
 
     Long getUserNo();
+
+    void afterLogin(long userNo, String token);
 }

--- a/src/main/java/com/festa/common/commonService/LoginService.java
+++ b/src/main/java/com/festa/common/commonService/LoginService.java
@@ -19,6 +19,6 @@ public interface LoginService {
 
     Long getUserNo();
 
-    void afterLogin(long userNo, String token);
+    void successLogin(long userNo, String token);
 
 }

--- a/src/main/java/com/festa/common/commonService/LoginService.java
+++ b/src/main/java/com/festa/common/commonService/LoginService.java
@@ -20,4 +20,6 @@ public interface LoginService {
     Long getUserNo();
 
     void afterLogin(long userNo, String token);
+
+    void removeToken(long userNo);
 }

--- a/src/main/java/com/festa/common/commonService/LoginService.java
+++ b/src/main/java/com/festa/common/commonService/LoginService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 @Service
 public interface LoginService {
 
-    void login(Long userNo, String token);
+    void login(Long userNo, String userId, String password, String token);
 
     void logout(long userNo);
 

--- a/src/main/java/com/festa/common/commonService/LoginService.java
+++ b/src/main/java/com/festa/common/commonService/LoginService.java
@@ -11,14 +11,12 @@ import org.springframework.stereotype.Service;
 @Service
 public interface LoginService {
 
-    void setUserNo(Long userNo);
+    void login(Long userNo, String token);
 
     void logout(long userNo);
 
     boolean isLoginUser();
 
     Long getUserNo();
-
-    void successLogin(long userNo, String token);
 
 }

--- a/src/main/java/com/festa/common/commonService/LoginService.java
+++ b/src/main/java/com/festa/common/commonService/LoginService.java
@@ -13,7 +13,7 @@ public interface LoginService {
 
     void setUserNo(Long userNo);
 
-    void removeUserNo();
+    void logout(long userNo);
 
     boolean isLoginUser();
 
@@ -21,5 +21,4 @@ public interface LoginService {
 
     void afterLogin(long userNo, String token);
 
-    void removeToken(long userNo);
 }

--- a/src/main/java/com/festa/common/firebase/FirebaseTokenManager.java
+++ b/src/main/java/com/festa/common/firebase/FirebaseTokenManager.java
@@ -1,19 +1,11 @@
 package com.festa.common.firebase;
 
-import com.festa.exception.FcmTokenException;
-import com.google.auth.oauth2.GoogleCredentials;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.Arrays;
 
 @Component
 @Log4j2

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -136,8 +136,7 @@ public class MemberController {
     @CheckLoginStatus(auth = UserLevel.USER)
     @PostMapping("/logout")
     public void logout(@CurrentLoginUserNo long userNo) {
-        loginService.removeUserNo();
-        loginService.removeToken(userNo);
+        loginService.logout(userNo);
     }
 
     /**

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -121,17 +121,14 @@ public class MemberController {
      */
     @PostMapping("/login")
     public ResponseEntity<HttpStatus> login(@RequestBody MemberLogin memberLogin) {
-        String userNo = String.valueOf(memberLogin.getUserNo());
         String userId = memberLogin.getUserId();
         String password = memberLogin.getPassword();
+        String token = memberLogin.getToken();
+        long userNo = memberService.getUserNo(userId);
 
         memberService.isUserIdExist(userId, password);
-        loginService.setUserNo(memberLogin.getUserNo());
-
-        firebaseTokenManager.register(userNo, memberLogin.getToken());
-
-        alertService.eventStartNotice(memberLogin.getUserNo(), LocalDate.now());
-        alertService.changePasswordNotice(memberLogin.getUserNo());
+        loginService.setUserNo(userNo);
+        loginService.afterLogin(userNo, token);
 
         return RESPONSE_ENTITY_OK;
     }

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -122,7 +122,7 @@ public class MemberController {
 
         memberService.isUserIdExist(userId, password);
         loginService.setUserNo(userNo);
-        loginService.afterLogin(userNo, token);
+        loginService.successLogin(userNo, token);
 
         return RESPONSE_ENTITY_OK;
     }

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -4,7 +4,6 @@ import com.festa.aop.CheckLoginStatus;
 import com.festa.common.UserLevel;
 import com.festa.common.commonService.LoginService;
 import com.festa.common.commonService.CurrentLoginUserNo;
-import com.festa.common.firebase.FirebaseTokenManager;
 import com.festa.dto.MemberDTO;
 import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
@@ -23,10 +22,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import com.festa.common.util.ConvertDataType;
 
 import java.net.URI;
-import java.time.LocalDate;
 
 import static com.festa.common.ResponseEntityConstants.RESPONSE_ENTITY_NOT_FOUND;
 import static com.festa.common.ResponseEntityConstants.RESPONSE_ENTITY_OK;
@@ -51,7 +48,6 @@ public class MemberController {
 
     private final MemberService memberService;
     private final LoginService loginService;
-    private final FirebaseTokenManager firebaseTokenManager;
 
     /**
      * 사용자 회원가입 기능
@@ -141,9 +137,7 @@ public class MemberController {
     @PostMapping("/logout")
     public void logout(@CurrentLoginUserNo long userNo) {
         loginService.removeUserNo();
-
-        String string_userNo = ConvertDataType.longToString(userNo);
-        firebaseTokenManager.removeToken(string_userNo);
+        loginService.removeToken(userNo);
     }
 
     /**

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -119,8 +119,7 @@ public class MemberController {
         String token = memberLogin.getToken();
         long userNo = memberService.getUserNo(userId);
 
-        memberService.isUserIdExist(userId, password);
-        loginService.login(userNo, token);
+        loginService.login(userNo, userId, password, token);
     }
 
     /**

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -111,10 +111,9 @@ public class MemberController {
      * 사용자 로그인 기능
      * Firebase Token 생성 후 로그인한 회원에게 보내야 할 알림여부를 응답을 보냄
      * @param memberLogin
-     * @return {@literal CompletableFuture<List<AlertResponse>>}
      */
     @PostMapping("/login")
-    public ResponseEntity<HttpStatus> login(@RequestBody MemberLogin memberLogin) {
+    public void login(@RequestBody MemberLogin memberLogin) {
         String userId = memberLogin.getUserId();
         String password = memberLogin.getPassword();
         String token = memberLogin.getToken();
@@ -123,8 +122,6 @@ public class MemberController {
         memberService.isUserIdExist(userId, password);
         loginService.setUserNo(userNo);
         loginService.successLogin(userNo, token);
-
-        return RESPONSE_ENTITY_OK;
     }
 
     /**

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -8,7 +8,6 @@ import com.festa.common.firebase.FirebaseTokenManager;
 import com.festa.dto.MemberDTO;
 import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
-import com.festa.service.AlertService;
 import com.festa.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -51,7 +50,6 @@ import static com.festa.common.ResponseEntityConstants.RESPONSE_ENTITY_OK;
 public class MemberController {
 
     private final MemberService memberService;
-    private final AlertService alertService;
     private final LoginService loginService;
     private final FirebaseTokenManager firebaseTokenManager;
 

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -120,8 +120,7 @@ public class MemberController {
         long userNo = memberService.getUserNo(userId);
 
         memberService.isUserIdExist(userId, password);
-        loginService.setUserNo(userNo);
-        loginService.successLogin(userNo, token);
+        loginService.login(userNo, token);
     }
 
     /**

--- a/src/main/java/com/festa/model/MemberLogin.java
+++ b/src/main/java/com/festa/model/MemberLogin.java
@@ -7,8 +7,6 @@ import javax.validation.constraints.NotBlank;
 @Value
 public class MemberLogin {
 
-    long userNo;
-
     @NotBlank(message = "아이디를 입력해주세요")
     String userId;
 

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -45,9 +45,6 @@ class MemberControllerTests {
     @MockBean
     private FirebaseTokenManager firebaseTokenManager;
 
-    @MockBean
-    private AlertService alertService;
-
     private MockHttpSession mockHttpSession;
 
     @BeforeEach
@@ -140,17 +137,17 @@ class MemberControllerTests {
     @Test
     public void whenExistedMemberRequestLoginThenSuccessLoginTest() throws Exception {
         MemberLogin loginInfo = new MemberLogin("rbdl879", "test123##", "abc123");
-        long userNo = memberService.getUserNo(loginInfo.getUserId());
-
-        doNothing().when(memberService).isUserIdExist("rbdl879", "test123##");
 
         this.mockMvc.perform(post("/members/login")
-                                .accept(MediaType.APPLICATION_JSON)
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content( "\"userId\":\"rbdl879\"," +
+                                .content( "{\"userId\":\"rbdl879\"," +
                                           "\"password\":\"test123##\"," +
                                           "\"token\":\"abc123\"}"))
+
                                 .andExpect(status().isOk());
+
+        long userNo = memberService.getUserNo(loginInfo.getUserId());
+        doNothing().when(memberService).isUserIdExist(loginInfo.getUserId(), loginInfo.getPassword());
 
         then(loginService).should().setUserNo(userNo);
         then(loginService).should().afterLogin(userNo, loginInfo.getToken());
@@ -165,7 +162,7 @@ class MemberControllerTests {
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}/password")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content( "\"userId\":\"rbdl879\"," +
+                .content( "{\"userId\":\"rbdl879\"," +
                           "\"password\":\"test123##\"," +
                           "\"token\":\"abc123\"}"));
 
@@ -181,7 +178,7 @@ class MemberControllerTests {
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content( "\"userId\":\"rbdl879\"," +
+                .content( "{\"userId\":\"rbdl879\"," +
                           "\"password\":\" \"," +
                           "\"token\":\"abc123\"}"));
 
@@ -191,18 +188,19 @@ class MemberControllerTests {
     @DisplayName("로그인한 아이디와 비밀번호를 입력하면 비밀번호 변경에 성공한다.")
     @Test
     public void whenUserIdAndPasswordIsNotNullThenSuccessChangePwTest() throws Exception {
-        given(loginService.getUserNo()).willReturn(1L);
+        long userNo = 1;
+        given(loginService.getUserNo()).willReturn(userNo);
         MemberLogin loginInfo = new MemberLogin("rbdl879", "test123##", "abc123");
 
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content( "\"userId\":\"rbdl879\"," +
+                .content( "{\"userId\":\"rbdl879\"," +
                           "\"password\":\"test123##\"," +
                           "\"token\":\"abc123\"}"))
                 .andExpect(status().isOk());
 
-        then(memberService).should().changeUserPw(1L, loginInfo.getPassword());
+        then(memberService).should().changeUserPw(userNo, loginInfo.getPassword());
     }
 
     @DisplayName("회원의 식별번호인 userNo가 null이라면 로그인한 회원이 아니기 때문에 회원탈퇴에 실패한다.")
@@ -214,7 +212,7 @@ class MemberControllerTests {
         this.mockMvc.perform(delete("/members", "/")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"userNo\":\" \""));
+                .content("{\"userNo\":\" \"}"));
 
         assertNull(userNo);
     }
@@ -228,7 +226,7 @@ class MemberControllerTests {
         this.mockMvc.perform(delete("/members/")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"userNo\":\"1\""))
+                .content("{\"userNo\":\"1\"}"))
                 .andExpect(status().isOk());
 
         then(memberService).should().memberWithdraw(userNo);
@@ -243,7 +241,7 @@ class MemberControllerTests {
                 .param("userNo", userNo)
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"userNo\":\" \""));
+                .content("{\"userNo\":\" \"}"));
 
         assertNull(userNo);
     }
@@ -257,7 +255,7 @@ class MemberControllerTests {
         this.mockMvc.perform(post("/members/logout")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"userNo\":\"1\""))
+                .content("{\"userNo\":\"1\"}"))
                 .andExpect(status().isOk());
 
         then(loginService).should().removeUserNo();

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -156,8 +156,7 @@ class MemberControllerTests {
         long userNo = memberService.getUserNo(loginInfo.getUserId());
         doNothing().when(memberService).isUserIdExist(loginInfo.getUserId(), loginInfo.getPassword());
 
-        then(loginService).should().setUserNo(userNo);
-        then(loginService).should().successLogin(userNo, loginInfo.getToken());
+        then(loginService).should().login(userNo, loginInfo.getToken());
     }
 
     @DisplayName("회원 식별번호인 userNo가 null이라면 로그인한 회원이 아니기 때문에 비밀번호 변경에 실패한다.")

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -59,6 +59,9 @@ class MemberControllerTests {
     }
 
     private static final long USER_NO = 1;
+    private static final String USER_ID = "rbdl879";
+    private static final String PASSWORD = "test123##";
+    private static final String TOKEN = "abc123";
 
     public MemberDTO existedMemberInfo() {
         return MemberDTO.builder()
@@ -144,7 +147,7 @@ class MemberControllerTests {
     @DisplayName("존재하는 회원이 로그인 요청을 하면 정상적으로 로그인한다.")
     @Test
     public void whenExistedMemberRequestLoginThenSuccessLoginTest() throws Exception {
-        MemberLogin loginInfo = new MemberLogin("rbdl879", "test123##", "abc123");
+        MemberLogin loginInfo = new MemberLogin(USER_ID, PASSWORD, TOKEN);
 
         this.mockMvc.perform(post("/members/login")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -153,10 +156,10 @@ class MemberControllerTests {
                                           "\"token\":\"abc123\"}"))
                                 .andExpect(status().isOk());
 
-        long userNo = memberService.getUserNo(loginInfo.getUserId());
-        doNothing().when(memberService).isUserIdExist(loginInfo.getUserId(), loginInfo.getPassword());
+        long userNo = memberService.getUserNo(USER_ID);
+        doNothing().when(memberService).isUserIdExist(USER_ID, PASSWORD);
 
-        then(loginService).should().login(userNo, loginInfo.getToken());
+        then(loginService).should().login(userNo, USER_ID, PASSWORD, TOKEN);
     }
 
     @DisplayName("회원 식별번호인 userNo가 null이라면 로그인한 회원이 아니기 때문에 비밀번호 변경에 실패한다.")
@@ -179,7 +182,7 @@ class MemberControllerTests {
     @Test
     public void whenPasswordNullThenFailChangeUserPwTest() throws Exception {
         given(loginService.getUserNo()).willReturn(USER_NO);
-        MemberLogin loginInfo = new MemberLogin("rbdl879", "", "abc123");
+        MemberLogin loginInfo = new MemberLogin(USER_ID, "", TOKEN);
 
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
                 .accept(MediaType.APPLICATION_JSON)
@@ -195,7 +198,7 @@ class MemberControllerTests {
     @Test
     public void whenUserIdAndPasswordIsNotNullThenSuccessChangePwTest() throws Exception {
         given(loginService.getUserNo()).willReturn(USER_NO);
-        MemberLogin loginInfo = new MemberLogin("rbdl879", "test123##", "abc123");
+        MemberLogin loginInfo = new MemberLogin(USER_ID, PASSWORD, TOKEN);
 
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
                 .accept(MediaType.APPLICATION_JSON)
@@ -205,7 +208,7 @@ class MemberControllerTests {
                           "\"token\":\"abc123\"}"))
                 .andExpect(status().isOk());
 
-        then(memberService).should().changeUserPw(USER_NO, loginInfo.getPassword());
+        then(memberService).should().changeUserPw(USER_NO, PASSWORD);
     }
 
     @DisplayName("회원의 식별번호인 userNo가 null이라면 로그인한 회원이 아니기 때문에 회원탈퇴에 실패한다.")

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -139,7 +139,7 @@ class MemberControllerTests {
     @DisplayName("존재하는 회원이 로그인 요청을 하면 정상적으로 로그인한다.")
     @Test
     public void whenExistedMemberRequestLoginThenSuccessLoginTest() throws Exception {
-        MemberLogin loginInfo = new MemberLogin(1L, "rbdl879", "test123##", "abc123");
+        MemberLogin loginInfo = new MemberLogin("rbdl879", "test123##", "abc123");
         long userNo = memberService.getUserNo(loginInfo.getUserId());
 
         doNothing().when(memberService).isUserIdExist("rbdl879", "test123##");
@@ -147,8 +147,7 @@ class MemberControllerTests {
         this.mockMvc.perform(post("/members/login")
                                 .accept(MediaType.APPLICATION_JSON)
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content("{\"userNo\":\"1\"," +
-                                          "\"userId\":\"rbdl879\"," +
+                                .content( "\"userId\":\"rbdl879\"," +
                                           "\"password\":\"test123##\"," +
                                           "\"token\":\"abc123\"}"))
                                 .andExpect(status().isOk());
@@ -162,13 +161,11 @@ class MemberControllerTests {
     public void whenUserNoNullThenFailChangeUserPwTest() throws Exception {
         Long userNo = (Long) mockHttpSession.getAttribute("USER_NO");
         given(loginService.getUserNo()).willReturn(userNo);
-        MemberLogin loginInfo = new MemberLogin(0, "rbdl879", "test123##", "abc123");
 
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}/password")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"userNo\":\" \"," +
-                          "\"userId\":\"rbdl879\"," +
+                .content( "\"userId\":\"rbdl879\"," +
                           "\"password\":\"test123##\"," +
                           "\"token\":\"abc123\"}"));
 
@@ -179,13 +176,12 @@ class MemberControllerTests {
     @Test
     public void whenPasswordNullThenFailChangeUserPwTest() throws Exception {
         given(loginService.getUserNo()).willReturn(1L);
-        MemberLogin loginInfo = new MemberLogin(1L, "rbdl879", "", "abc123");
+        MemberLogin loginInfo = new MemberLogin("rbdl879", "", "abc123");
 
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"userNo\":\"1\"," +
-                          "\"userId\":\"rbdl879\"," +
+                .content( "\"userId\":\"rbdl879\"," +
                           "\"password\":\" \"," +
                           "\"token\":\"abc123\"}"));
 
@@ -196,13 +192,12 @@ class MemberControllerTests {
     @Test
     public void whenUserIdAndPasswordIsNotNullThenSuccessChangePwTest() throws Exception {
         given(loginService.getUserNo()).willReturn(1L);
-        MemberLogin loginInfo = new MemberLogin(1L, "rbdl879", "test123##", "abc123");
+        MemberLogin loginInfo = new MemberLogin("rbdl879", "test123##", "abc123");
 
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"userNo\":\"1\"," +
-                          "\"userId\":\"rbdl879\"," +
+                .content( "\"userId\":\"rbdl879\"," +
                           "\"password\":\"test123##\"," +
                           "\"token\":\"abc123\"}"))
                 .andExpect(status().isOk());

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -7,7 +7,6 @@ import com.festa.controller.MemberController;
 import com.festa.dto.MemberDTO;
 import com.festa.model.MemberInfo;
 import com.festa.model.MemberLogin;
-import com.festa.service.AlertService;
 import com.festa.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -140,6 +140,7 @@ class MemberControllerTests {
     @Test
     public void whenExistedMemberRequestLoginThenSuccessLoginTest() throws Exception {
         MemberLogin loginInfo = new MemberLogin(1L, "rbdl879", "test123##", "abc123");
+        long userNo = memberService.getUserNo(loginInfo.getUserId());
 
         doNothing().when(memberService).isUserIdExist("rbdl879", "test123##");
 
@@ -152,7 +153,8 @@ class MemberControllerTests {
                                           "\"token\":\"abc123\"}"))
                                 .andExpect(status().isOk());
 
-        then(loginService).should().setUserNo(loginInfo.getUserNo());
+        then(loginService).should().setUserNo(userNo);
+        then(loginService).should().afterLogin(userNo, loginInfo.getToken());
     }
 
     @DisplayName("회원 식별번호인 userNo가 null이라면 로그인한 회원이 아니기 때문에 비밀번호 변경에 실패한다.")

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -116,7 +116,7 @@ class MemberControllerTests {
                 .param("userNo", "1"))
                 .andExpect(status().isOk());
 
-        then(memberService).should().getUser(1);
+        then(memberService).should().getUser(USER_NO);
     }
 
     @DisplayName("삭제된 사용자정보를 조회하는 경우 404 상태코드를 리턴한다.")
@@ -190,7 +190,7 @@ class MemberControllerTests {
                           "\"password\":\" \"," +
                           "\"token\":\"abc123\"}"));
 
-        then(memberService).should(never()).changeUserPw(1L, loginInfo.getPassword());
+        then(memberService).should(never()).changeUserPw(USER_NO, loginInfo.getPassword());
     }
 
     @DisplayName("로그인한 아이디와 비밀번호를 입력하면 비밀번호 변경에 성공한다.")

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -158,7 +158,7 @@ class MemberControllerTests {
         doNothing().when(memberService).isUserIdExist(loginInfo.getUserId(), loginInfo.getPassword());
 
         then(loginService).should().setUserNo(userNo);
-        then(loginService).should().afterLogin(userNo, loginInfo.getToken());
+        then(loginService).should().successLogin(userNo, loginInfo.getToken());
     }
 
     @DisplayName("회원 식별번호인 userNo가 null이라면 로그인한 회원이 아니기 때문에 비밀번호 변경에 실패한다.")

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -20,13 +20,20 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(MemberController.class)

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -58,6 +58,8 @@ class MemberControllerTests {
         mockHttpSession = new MockHttpSession();
     }
 
+    private static final long USER_NO = 1;
+
     public MemberDTO existedMemberInfo() {
         return MemberDTO.builder()
                 .userNo(1)
@@ -108,7 +110,7 @@ class MemberControllerTests {
     @DisplayName("존재하는 사용자정보를 조회하는 경우 200 상태코드를 리턴한다.")
     @Test
     public void whenUserInfoIsExistedThenResponseOKGetUserTest() throws Exception {
-        given(memberService.getUser(1)).willReturn(existedMemberInfo());
+        given(memberService.getUser(USER_NO)).willReturn(existedMemberInfo());
 
         this.mockMvc.perform(get("/members/{userNo}", "{userNo}")
                 .param("userNo", "1"))
@@ -178,7 +180,7 @@ class MemberControllerTests {
     @DisplayName("비밀번호를 입력하지 않는다면 비밀번호 변경에 실패한다.")
     @Test
     public void whenPasswordNullThenFailChangeUserPwTest() throws Exception {
-        given(loginService.getUserNo()).willReturn(1L);
+        given(loginService.getUserNo()).willReturn(USER_NO);
         MemberLogin loginInfo = new MemberLogin("rbdl879", "", "abc123");
 
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
@@ -194,8 +196,7 @@ class MemberControllerTests {
     @DisplayName("로그인한 아이디와 비밀번호를 입력하면 비밀번호 변경에 성공한다.")
     @Test
     public void whenUserIdAndPasswordIsNotNullThenSuccessChangePwTest() throws Exception {
-        long userNo = 1;
-        given(loginService.getUserNo()).willReturn(userNo);
+        given(loginService.getUserNo()).willReturn(USER_NO);
         MemberLogin loginInfo = new MemberLogin("rbdl879", "test123##", "abc123");
 
         this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
@@ -206,7 +207,7 @@ class MemberControllerTests {
                           "\"token\":\"abc123\"}"))
                 .andExpect(status().isOk());
 
-        then(memberService).should().changeUserPw(userNo, loginInfo.getPassword());
+        then(memberService).should().changeUserPw(USER_NO, loginInfo.getPassword());
     }
 
     @DisplayName("회원의 식별번호인 userNo가 null이라면 로그인한 회원이 아니기 때문에 회원탈퇴에 실패한다.")
@@ -226,8 +227,7 @@ class MemberControllerTests {
     @DisplayName("로그인한 상태라면 세션에서 회원번호를 읽어와 해당 회원의 탈퇴에 성공한다.")
     @Test
     public void whenUserNoIsNotNullThenSuccessMemberWithdrawTest() throws Exception {
-        long userNo = 1L;
-        given(loginService.getUserNo()).willReturn(userNo);
+        given(loginService.getUserNo()).willReturn(USER_NO);
 
         this.mockMvc.perform(delete("/members/")
                 .accept(MediaType.APPLICATION_JSON)
@@ -235,7 +235,7 @@ class MemberControllerTests {
                 .content("{\"userNo\":\"1\"}"))
                 .andExpect(status().isOk());
 
-        then(memberService).should().memberWithdraw(userNo);
+        then(memberService).should().memberWithdraw(USER_NO);
     }
 
     @DisplayName("회원 식별번호인 userNo가 null이라면 로그인한 상태가 아니기 때문에 로그아웃에 실패한다.")
@@ -255,8 +255,7 @@ class MemberControllerTests {
     @DisplayName("로그인한 상태라면 세션에서 회원번호를 읽어와 로그아웃에 성공한다.")
     @Test
     public void whenUserNoIsNotNullThenSuccessLogoutTest() throws Exception {
-        String userNo = "1";
-        given(loginService.getUserNo()).willReturn(1L);
+        given(loginService.getUserNo()).willReturn(USER_NO);
 
         this.mockMvc.perform(post("/members/logout")
                 .accept(MediaType.APPLICATION_JSON)
@@ -264,8 +263,8 @@ class MemberControllerTests {
                 .content("{\"userNo\":\"1\"}"))
                 .andExpect(status().isOk());
 
-        then(loginService).should().removeUserNo();
-        firebaseTokenManager.removeToken(userNo);
+        then(loginService).should().logout(USER_NO);
+        firebaseTokenManager.removeToken(String.valueOf(USER_NO));
     }
 
     @DisplayName("참여자 정보 수정 시 해당 회원정보도 함께 수정할지에 대한 여부가 True 라면 해당 회원의 회원정보와 이벤트 참여자 정보 모두 수정한다.")

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -151,7 +151,6 @@ class MemberControllerTests {
                                 .content( "{\"userId\":\"rbdl879\"," +
                                           "\"password\":\"test123##\"," +
                                           "\"token\":\"abc123\"}"))
-
                                 .andExpect(status().isOk());
 
         long userNo = memberService.getUserNo(loginInfo.getUserId());

--- a/src/test/java/com/festa/MemberServiceTests.java
+++ b/src/test/java/com/festa/MemberServiceTests.java
@@ -31,13 +31,6 @@ class MemberServiceTests {
     @Mock
     private MemberDAO memberDAO;
 
-    private MockHttpSession mockHttpSession;
-
-    @BeforeEach
-    public void setUp() {
-        mockHttpSession = new MockHttpSession();
-    }
-
     public MemberDTO memberInfoSetUp() {
         return MemberDTO.builder()
                 .userId("rbdl879")
@@ -100,18 +93,17 @@ class MemberServiceTests {
     @DisplayName("회원 로그인 성공")
     @Test
     public void loginTest() {
-        MemberLogin memberLogin = new MemberLogin(5, "rbdl879", "test123#", "abc123");
+        MemberLogin memberLogin = new MemberLogin("rbdl879", "test123#", "abc123");
 
-        when(memberDAO.isUserIdExist(memberLogin.getUserId(), memberLogin.getPassword())).thenReturn(false);
-        mockHttpSession.setAttribute("USER_NO", memberLogin.getUserNo());
+        when(memberDAO.isUserIdExist(memberLogin.getUserId(), memberLogin.getPassword())).thenReturn(true);
 
-        assertEquals(memberLogin.getUserNo(), mockHttpSession.getAttribute("USER_NO"));
+        assertEquals(memberLogin.getUserId(), "rbdl879");
     }
 
     @DisplayName("탈퇴한 아이디가 로그인 요청이 오면 IllegalStateException이 발생한다")
     @Test
     public void deletedIdLoginTest() {
-        MemberLogin memberLogin = new MemberLogin(1, "jes7077", "test123#", "abc123");
+        MemberLogin memberLogin = new MemberLogin("jes7077", "test123#", "abc123");
 
         when(memberDAO.isUserIdExist(memberLogin.getUserId(), memberLogin.getPassword())).thenReturn(false);
 
@@ -121,11 +113,11 @@ class MemberServiceTests {
     @DisplayName("아이디가 불일치할 경우 로그인에 실패한다")
     @Test
     public void loginUserIdMismatchTest() {
-        MemberLogin memberLogin = new MemberLogin(5, "jeje12", "test123#", "abc123");
+        MemberLogin memberLogin = new MemberLogin("jeje12", "test123#", "abc123");
 
         when(memberDAO.getUserNoById(memberLogin.getUserId())).thenReturn(7L);
 
-        assertNotEquals(memberLogin.getUserNo(),7);
+        assertNotEquals(memberLogin.getUserId(),"jeje123");
     }
 
     @DisplayName("사용자 탈퇴 시 회원정보 일치하면 회원탈퇴에 성공한다")

--- a/src/test/java/com/festa/UserSignUpValidationTests.java
+++ b/src/test/java/com/festa/UserSignUpValidationTests.java
@@ -271,7 +271,7 @@ public class UserSignUpValidationTests {
     @DisplayName("아이디가 null일 경우 로그인 실패")
     @Test
     public void loginUserIdNullTest() {
-        MemberLogin memberLogin = new MemberLogin(5, null, "test123#", "abc123");
+        MemberLogin memberLogin = new MemberLogin(null, "test123#", "abc123");
 
         Set<ConstraintViolation<MemberLogin>> violations = validator.validate(memberLogin);
 
@@ -282,7 +282,7 @@ public class UserSignUpValidationTests {
     @DisplayName("아이디가 공백일 경우 로그인 실패")
     @Test
     public void loginUserIdBlankTest() {
-        MemberLogin memberLogin = new MemberLogin(5, " ", "test123#", "abc123");
+        MemberLogin memberLogin = new MemberLogin(" ", "test123#", "abc123");
 
         Set<ConstraintViolation<MemberLogin>> violations = validator.validate(memberLogin);
 


### PR DESCRIPTION
- `SessionLogin` -> `SessionLoginService` 로 변경: 구현체의 명확한 의미를 위함
- 로그인 시 키값 `userNo` 받는 부분 제거
- 메서드 수정으로 단위테스트 일부도 같이 수정되었습니다
- MemberController `login()` 반환타입 `void` 로 수정