### PR TITLE
이벤트 관련 쿼리 수정

### DIFF
--- a/src/main/resources/mapper/EventsMapper.xml
+++ b/src/main/resources/mapper/EventsMapper.xml
@@ -101,8 +101,9 @@
             P.cancelDate,
             P.participateDate
         FROM participant P
-        LEFT OUTER JOIN participant_address PA
+        INNER JOIN participant_address PA
         on P.eventNo = PA.eventNo
+        and P.userNo = PA.userNo
         INNER JOIN members M
         on P.userNo = M.userNo
         WHERE P.eventNo = #{eventNo}

--- a/src/main/resources/mapper/EventsMapper.xml
+++ b/src/main/resources/mapper/EventsMapper.xml
@@ -235,7 +235,7 @@
         UPDATE events
             SET noOfParticipants = noOfParticipants - 1
         WHERE eventNo = #{eventNo}
-            AND noOfParticipants <![CDATA[<]]> participantLimit
+            AND noOfParticipants <![CDATA[<=]]> participantLimit
     </update>
 
     <delete id="deleteEvent" parameterType="long">


### PR DESCRIPTION
sql 성능튜닝을 하기 위해 이벤트 관련 쿼리들을 살펴보던 중 수정해야할 것들이 있어 수정하였습니다.

1. `getParticipantList` 수정
이전에는 LEFT OUTER JOIN을 이용하여 participant와 participant_address를 합쳐주고 있었습니다.
하지만 아래의 WHERE에서 participant의 eventNo 가 일치하는 것을 다시 찾아서 조회하는 것을 확인하였고,
이럴경우 옵티마이저는 자동으로 쿼리를 INNER JOIN으로 변경하여 결과를 출력하기 때문에 WHERE의 조건을 JOIN ON에 추가해주거나 INNER JOIN으로 수정해주는 것을 권장한다는 글을 보았습니다.<br>
그리고 participant와 participant_address 모두 인덱스가 없는 상황이라 풀 스캔 중인데 이럴경우 OUTER JOIN을 사용하면 테이블을 읽는 순서가 강제되고, INNER JOIN을 사용하면 옵티마이저가 다양한 방법으로 최적화를 수행할 수 있다고 합니다.<br>
이벤트를 신청할 때 participant_address에도 반드시 주소를 기입해야하기 때문에 participant와 일치하지 않는 조건은 나타나지 않습니다. 그래서 LEFT OUTER JOIN을 하는것 보다는 INNER JOIN으로 하는것이 좋을것같아 수정하였습니다.

2. `reduceParticipants` 수정
noOfParticipants < participantLimit로 할 경우 참가자 수가 꽉 찼을경우 참가자 수를 줄일 수 없으므로 부등호를 <=로 수정하였습니다.