### PR TITLE
이벤트 신청 취소 기능 수정

### DIFF
--- a/src/main/java/com/festa/dao/EventDAO.java
+++ b/src/main/java/com/festa/dao/EventDAO.java
@@ -36,7 +36,7 @@ public interface EventDAO {
 
     void increaseParticipants(long eventNo);
 
-    void reduceParticipants(long eventNo);
+    void reduceParticipants(Participants participants);
 
     EventDTO checkNoOfParticipants(long eventNo);
 

--- a/src/main/java/com/festa/service/EventService.java
+++ b/src/main/java/com/festa/service/EventService.java
@@ -95,7 +95,7 @@ public class EventService {
             throw new IllegalStateException("접수한 이벤트가 아닙니다");
         }
 
-        eventDAO.reduceParticipants(participants.getEventNo());
+        eventDAO.reduceParticipants(participants);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/mapper/EventsMapper.xml
+++ b/src/main/resources/mapper/EventsMapper.xml
@@ -216,10 +216,11 @@
         WHERE eventNo = #{eventNo}
     </update>
 
-    <update id="cancelEvent" parameterType="long">
+    <update id="cancelEvent" parameterType="com.festa.model.Participants">
         UPDATE participant
             SET cancelDate = NOW()
         WHERE userNo = #{userNo}
+            AND eventNo = #{eventNo}
             AND applyDate IS NOT NULL
     </update>
 

--- a/src/test/java/com/festa/service/EventServiceTest.java
+++ b/src/test/java/com/festa/service/EventServiceTest.java
@@ -264,14 +264,14 @@ class EventServiceTest {
 
         when(eventDAO.isParticipated(participants.getUserNo())).thenReturn(true);
 
-        doNothing().when(eventDAO).reduceParticipants(participants.getEventNo());
+        doNothing().when(eventDAO).reduceParticipants(participants);
 
         // when
         eventService.cancelEvent(participants);
 
         // then
         verify(eventDAO).cancelEvent(participants.getUserNo());
-        verify(eventDAO).reduceParticipants(participants.getEventNo());
+        verify(eventDAO).reduceParticipants(participants);
     }
 
     @Test


### PR DESCRIPTION
이벤트 신청 취소인 cancelEvent에서 userNo만 비교 시 해당 참가자가 신청한 모든 이벤트가 신청 취소되기 때문에 eventNo도 조건으로 추가하였습니다.
그리고 cancelEvent의 parameterType이 수정되었기 때문에 관련된 메서드들과 테스트도 추가 수정하였습니다.