### PR TITLE
비밀번호 수정 기능 수정

### DIFF
--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.festa.common.commonService.CurrentLoginUserNo;
 import com.festa.dto.MemberDTO;
 import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
+import com.festa.model.MemberNewPw;
 import com.festa.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -140,9 +141,9 @@ public class MemberController {
      * @return {@literal ResponseEntity<HttpStatus>}
      */
     @CheckLoginStatus(auth = UserLevel.USER)
-    @PatchMapping("/{userId}/password")
-    public void changePassword(@CurrentLoginUserNo long userNo, @RequestBody MemberLogin memberLogin) {
-        memberService.changeUserPw(userNo, memberLogin.getPassword());
+    @PatchMapping("/password")
+    public void changePassword(@CurrentLoginUserNo long userNo, @RequestBody MemberNewPw memberNewPw) {
+        memberService.changeUserPw(userNo, memberNewPw);
     }
 
     /**

--- a/src/main/java/com/festa/dao/MemberDAO.java
+++ b/src/main/java/com/festa/dao/MemberDAO.java
@@ -22,7 +22,7 @@ public interface MemberDAO {
 
     MemberDTO getUserByNo(long userNo);
 
-    void changeUserPw(long userNo, String password);
+    void changeUserPw(@Param("userNo") long userNo, @Param("newPassword") String newPassword);
 
     void modifyMemberInfoForWithdraw(long userNo);
 

--- a/src/main/java/com/festa/dao/MemberDAO.java
+++ b/src/main/java/com/festa/dao/MemberDAO.java
@@ -1,9 +1,9 @@
 package com.festa.dao;
 
 import com.festa.dto.MemberDTO;
-import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 @Mapper
@@ -30,7 +30,7 @@ public interface MemberDAO {
 
     long getUserNoById(String userId);
 
-    String getUserPassword(long userNo);
+    boolean isUserPasswordExist(@Param("userNo") long userNo, @Param("password")String password);
 
     boolean getChangePwDateDiff(long userNo);
 

--- a/src/main/java/com/festa/model/MemberNewPw.java
+++ b/src/main/java/com/festa/model/MemberNewPw.java
@@ -1,0 +1,17 @@
+package com.festa.model;
+
+import lombok.Getter;
+import lombok.Value;
+
+import javax.validation.constraints.NotBlank;
+
+@Value
+@Getter
+public class MemberNewPw {
+
+    @NotBlank(message = "비밀번호를 입력해주세요")
+    String password;
+
+    @NotBlank(message = "새로운 비밀번호를 입력해주세요")
+    String newPassword;
+}

--- a/src/main/java/com/festa/model/MemberNewPw.java
+++ b/src/main/java/com/festa/model/MemberNewPw.java
@@ -1,12 +1,10 @@
 package com.festa.model;
 
-import lombok.Getter;
 import lombok.Value;
 
 import javax.validation.constraints.NotBlank;
 
 @Value
-@Getter
 public class MemberNewPw {
 
     @NotBlank(message = "비밀번호를 입력해주세요")

--- a/src/main/java/com/festa/service/MemberService.java
+++ b/src/main/java/com/festa/service/MemberService.java
@@ -61,8 +61,8 @@ public class MemberService {
 
     public void changeUserPw(long userNo, String password) {
 
-        if(!memberDAO.getUserPassword(userNo).equals(password)) {
-            throw new IllegalArgumentException("일치하는 비밀번호가 없습니다.");
+        if(!memberDAO.isUserPasswordExist(userNo, password)) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
         memberDAO.changeUserPw(userNo, password);

--- a/src/main/java/com/festa/service/MemberService.java
+++ b/src/main/java/com/festa/service/MemberService.java
@@ -3,6 +3,7 @@ package com.festa.service;
 import com.festa.dao.MemberDAO;
 import com.festa.dto.MemberDTO;
 import com.festa.model.MemberInfo;
+import com.festa.model.MemberNewPw;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -59,13 +60,13 @@ public class MemberService {
         return memberDAO.getUserByNo(userNo);
     }
 
-    public void changeUserPw(long userNo, String password) {
+    public void changeUserPw(long userNo, MemberNewPw memberNewPw) {
 
-        if(!memberDAO.isUserPasswordExist(userNo, password)) {
+        if(!memberDAO.isUserPasswordExist(userNo, memberNewPw.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        memberDAO.changeUserPw(userNo, password);
+        memberDAO.changeUserPw(userNo, memberNewPw.getNewPassword());
     }
 
     public void memberWithdraw(long userNo) {

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -138,10 +138,13 @@
         where userNo = #{userNo}
     </select>
 
-    <select id="getUserPassword" parameterType="long">
-        SELECT
-            password
-        FROM members
-        WHERE userNo = #{userNo}
+    <select id="isUserPasswordExist">
+        SELECT EXISTS
+            (SELECT password
+            FROM members
+            WHERE userNo = #{userNo}
+            AND password = #{password}
+            )
+        AS isPasswordExists
     </select>
 </mapper>

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -86,9 +86,9 @@
             AND eventNo = #{eventNo}
     </update>
 
-    <update id="changeUserPw" parameterType="com.festa.dto.MemberDTO">
+    <update id="changeUserPw">
         UPDATE members
-            SET password = #{password},
+            SET password = #{newPassword},
                 updatePwDate = NOW()
         WHERE userNo = #{userNo}
     </update>

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -138,7 +138,7 @@
         where userNo = #{userNo}
     </select>
 
-    <select id="isUserPasswordExist">
+    <select id="isUserPasswordExist" resultType="boolean">
         SELECT EXISTS
             (SELECT password
             FROM members

--- a/src/test/java/com/festa/MemberControllerTests.java
+++ b/src/test/java/com/festa/MemberControllerTests.java
@@ -7,6 +7,7 @@ import com.festa.controller.MemberController;
 import com.festa.dto.MemberDTO;
 import com.festa.model.MemberInfo;
 import com.festa.model.MemberLogin;
+import com.festa.model.MemberNewPw;
 import com.festa.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -61,6 +62,7 @@ class MemberControllerTests {
     private static final long USER_NO = 1;
     private static final String USER_ID = "rbdl879";
     private static final String PASSWORD = "test123##";
+    private static final String NEWPASSWORD = "test*23#";
     private static final String TOKEN = "abc123";
 
     public MemberDTO existedMemberInfo() {
@@ -182,33 +184,31 @@ class MemberControllerTests {
     @Test
     public void whenPasswordNullThenFailChangeUserPwTest() throws Exception {
         given(loginService.getUserNo()).willReturn(USER_NO);
-        MemberLogin loginInfo = new MemberLogin(USER_ID, "", TOKEN);
+        MemberNewPw memberNewPw = new MemberNewPw("", NEWPASSWORD);
 
-        this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
+        this.mockMvc.perform(patch("/members/password")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content( "{\"userId\":\"rbdl879\"," +
-                          "\"password\":\" \"," +
-                          "\"token\":\"abc123\"}"));
+                .content( "{\"password\":\" \"," +
+                          "\"newPassword\":\"test*23#\"}"));
 
-        then(memberService).should(never()).changeUserPw(USER_NO, loginInfo.getPassword());
+        then(memberService).should(never()).changeUserPw(USER_NO, memberNewPw);
     }
 
     @DisplayName("로그인한 아이디와 비밀번호를 입력하면 비밀번호 변경에 성공한다.")
     @Test
     public void whenUserIdAndPasswordIsNotNullThenSuccessChangePwTest() throws Exception {
         given(loginService.getUserNo()).willReturn(USER_NO);
-        MemberLogin loginInfo = new MemberLogin(USER_ID, PASSWORD, TOKEN);
+        MemberNewPw memberNewPw = new MemberNewPw(PASSWORD, NEWPASSWORD);
 
-        this.mockMvc.perform(patch("/members/{userId}/password", "{userId}")
+        this.mockMvc.perform(patch("/members/password")
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content( "{\"userId\":\"rbdl879\"," +
-                          "\"password\":\"test123##\"," +
-                          "\"token\":\"abc123\"}"))
+                .content( "{\"password\":\"test123##\"," +
+                          "\"newPassword\":\"test*23#\"}"))
                 .andExpect(status().isOk());
 
-        then(memberService).should().changeUserPw(USER_NO, PASSWORD);
+        then(memberService).should().changeUserPw(USER_NO, memberNewPw);
     }
 
     @DisplayName("회원의 식별번호인 userNo가 null이라면 로그인한 회원이 아니기 때문에 회원탈퇴에 실패한다.")

--- a/src/test/java/com/festa/MemberServiceTests.java
+++ b/src/test/java/com/festa/MemberServiceTests.java
@@ -145,17 +145,17 @@ class MemberServiceTests {
     @DisplayName("기존 비밀번호가 일치할 경우 비밀번호 변경에 성공한다")
     @Test
     public void memberChangePwTest() {
-        given(memberDAO.getUserPassword(5)).willReturn("tt1234##");
+        given(memberDAO.isUserPasswordExist(5, "tt1234##")).willReturn(true);
 
         memberService.changeUserPw(5, "tt1234##");
 
-        assertEquals("tt1234##", memberDAO.getUserPassword(5));
+        assertEquals(true, memberDAO.isUserPasswordExist(5, "tt1234##"));
     }
 
     @DisplayName("기존 비밀번호가 불일치할 경우 IllegalArgumentException이 발생한다")
     @Test
     public void memberChangePwMismatchTest() {
-        when(memberDAO.getUserPassword(any(Long.class))).thenReturn("");
+        when(memberDAO.isUserPasswordExist(any(Long.class), any(String.class))).thenReturn(false);
 
         assertThrows(IllegalArgumentException.class, () -> memberService.changeUserPw(5, "tt1234##"));
     }

--- a/src/test/java/com/festa/MemberServiceTests.java
+++ b/src/test/java/com/festa/MemberServiceTests.java
@@ -5,6 +5,7 @@ import com.festa.dao.MemberDAO;
 import com.festa.dto.MemberDTO;
 import com.festa.model.MemberInfo;
 import com.festa.model.MemberLogin;
+import com.festa.model.MemberNewPw;
 import com.festa.service.MemberService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -145,9 +146,10 @@ class MemberServiceTests {
     @DisplayName("기존 비밀번호가 일치할 경우 비밀번호 변경에 성공한다")
     @Test
     public void memberChangePwTest() {
-        given(memberDAO.isUserPasswordExist(5, "tt1234##")).willReturn(true);
+        MemberNewPw memberNewPw = new MemberNewPw("tt1234##", "tt*23#");
+        given(memberDAO.isUserPasswordExist(5, memberNewPw.getPassword())).willReturn(true);
 
-        memberService.changeUserPw(5, "tt1234##");
+        memberService.changeUserPw(5, memberNewPw);
 
         assertEquals(true, memberDAO.isUserPasswordExist(5, "tt1234##"));
     }
@@ -155,9 +157,10 @@ class MemberServiceTests {
     @DisplayName("기존 비밀번호가 불일치할 경우 IllegalArgumentException이 발생한다")
     @Test
     public void memberChangePwMismatchTest() {
+        MemberNewPw memberNewPw = new MemberNewPw("tt1234##", "tt*23#");
         when(memberDAO.isUserPasswordExist(any(Long.class), any(String.class))).thenReturn(false);
 
-        assertThrows(IllegalArgumentException.class, () -> memberService.changeUserPw(5, "tt1234##"));
+        assertThrows(IllegalArgumentException.class, () -> memberService.changeUserPw(5, memberNewPw));
     }
 
     @DisplayName("사용자의 정보를 조회한다")


### PR DESCRIPTION
비밀번호를 DB 밖으로 가져와 비교하지1 않고 내부에서 비밀번호, 사용자번호가 일치하는 값이 존재하는지 여부를 가져와 확인하도록 수정하였습니다.
그리고 '일치하는 비밀번호가 존재하지 않습니다' 보다는 '비밀번호가 일치하지 않습니다'라는 문구가 더 적절한것같아 수정하였습니다!