### PR TITLE
MemberDAO 파라미터 수정

### DIFF
--- a/src/main/java/com/festa/dao/MemberDAO.java
+++ b/src/main/java/com/festa/dao/MemberDAO.java
@@ -4,6 +4,7 @@ import com.festa.dto.MemberDTO;
 import com.festa.model.MemberLogin;
 import com.festa.model.MemberInfo;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 @Mapper
@@ -14,24 +15,24 @@ public interface MemberDAO {
 
     void insertMemberAddress(MemberDTO memberDTO);
 
-    boolean isUserIdExist(String userId, String password);
+    boolean isUserIdExist(@Param("userId") String userId, @Param("password") String password);
 
     void modifyMemberInfo(MemberInfo memberInfo);
 
     void modifyMemberAddress(MemberInfo memberInfo);
 
-    MemberDTO getUserByNo(long userNo);
+    MemberDTO getUserByNo(@Param("userNo") long userNo);
 
-    void changeUserPw(long userNo, String password);
+    void changeUserPw(@Param("userNo") long userNo, @Param("password") String password);
 
-    void modifyMemberInfoForWithdraw(long userNo);
+    void modifyMemberInfoForWithdraw(@Param("userNo") long userNo);
 
     void modifyParticipantInfo(MemberInfo memberInfo);
 
-    long getUserNoById(String userId);
+    long getUserNoById(@Param("userId") String userId);
 
     String getUserPassword(long userNo);
 
-    boolean getChangePwDateDiff(long userNo);
+    boolean getChangePwDateDiff(@Param("userNo") long userNo);
 
 }

--- a/src/main/resources/mapper/MemberMapper.xml
+++ b/src/main/resources/mapper/MemberMapper.xml
@@ -86,14 +86,14 @@
             AND eventNo = #{eventNo}
     </update>
 
-    <update id="changeUserPw" parameterType="com.festa.dto.MemberDTO">
+    <update id="changeUserPw">
         UPDATE members
             SET password = #{password},
                 updatePwDate = NOW()
         WHERE userNo = #{userNo}
     </update>
 
-    <select id="getUserByNo" resultType="com.festa.dto.MemberDTO">
+    <select id="getUserByNo" parameterType="long" resultType="com.festa.dto.MemberDTO">
         SELECT
             M.userNo,
             M.userId,
@@ -115,14 +115,14 @@
           AND M.deleted = FALSE
     </select>
 
-    <update id="modifyMemberInfoForWithdraw" parameterType="com.festa.dto.MemberDTO">
+    <update id="modifyMemberInfoForWithdraw" parameterType="long">
         UPDATE members
             SET deleted = TRUE,
                 deletedDate = NOW()
         WHERE userNo = #{userNo};
     </update>
 
-    <select id="getUserNoById" resultType="long">
+    <select id="getUserNoById" parameterType="string" resultType="long">
         SELECT
             userNo
         FROM members
@@ -131,7 +131,7 @@
         AND deleted = FALSE
     </select>
 
-    <select id="getChangePwDateDiff" resultType="boolean">
+    <select id="getChangePwDateDiff" parameterType="long" resultType="boolean">
         SELECT
               IF(DATEDIFF(NOW(), updatePwDate) > 90, true, false)
         FROM members


### PR DESCRIPTION
MyBatis 문서를 보던 중 DAO에서 파라미터를 넘길 때 xml에서 설정해둔 parameterType과 일치하지 않더라도 ParameterHandler에 의해 자동으로 맵핑된다는 글을 보았습니다.

그런데 값이 여러개 넘어갈 경우 객체나 Map을 이용하지 않고 넘기면 넘어간 변수명과 쿼리에서 사용하는 이름이 같더라도 값이 넘어간 순서대로 맵핑되어서 값을 넘길 때 `@Param` 어노테이션을 이용하여 파라미터의 이름을 지정해주어야한다고 합니다. 이전에 작성한 메소드 중 DTO를 이용하지 않은 메소드들과, 맵핑되는 쿼리문의 parameterType이 일치하지 않는것들을 수정하였습니다..!

+getUserPassword 메서드는 #138에서 수정중이으므로 일단 제외하고 수정하였습니다..!