### PR TITLE
API URI 수정

### DIFF
--- a/src/main/java/com/festa/controller/EventController.java
+++ b/src/main/java/com/festa/controller/EventController.java
@@ -18,11 +18,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -54,7 +54,7 @@ public class EventController {
      * @return {@literal ResponseEntity<HttpStatus>}
      */
     @CheckLoginStatus(auth = UserLevel.USER)
-    @PostMapping("/{eventNo}/applies")
+    @PostMapping("/applies")
     public ResponseEntity<HttpStatus> applyForEvents(@RequestBody Participants participants) {
         try {
             eventService.applyForEvents(participants);
@@ -90,8 +90,8 @@ public class EventController {
      * @return EventDTO
      */
     @CheckLoginStatus(auth = UserLevel.USER)
-    @GetMapping("/{eventNo}")
-    public ResponseEntity<EventDTO> getInfoOfEvent(@PathVariable long eventNo) {
+    @GetMapping("/detail")
+    public ResponseEntity<EventDTO> getInfoOfEvent(@RequestParam long eventNo) {
         EventDTO infoOfEvent = eventService.getInfoOfEvent(eventNo);
 
         return ResponseEntity.ok(infoOfEvent);
@@ -119,11 +119,11 @@ public class EventController {
     /**
      * 주최자 이벤트 참여자 목록 조회 기능
      * @param userNo, eventNo
-     * @return {@literal ResponseEntity<HttpStatus>}
+     * @return {@literal List<Participants>}
      * @throws NoSuchElementException (조회된 데이터가 없을 경우)
      */
     @CheckLoginStatus(auth = UserLevel.HOST)
-    @GetMapping("/{eventNo}/participants")
+    @GetMapping("/participants")
     public List<Participants> getParticipantList(@CurrentLoginUserNo long userNo, long eventNo) {
         List<Participants> participantsList = eventService.getParticipantList(userNo, eventNo);
 
@@ -133,10 +133,10 @@ public class EventController {
     /**
      * 주최자 이벤트 수정 기능
      * @param eventDTO
-     * @return {@literal ResponseEntity<HttpStatus>}
+     * @return void
      */
     @CheckLoginStatus(auth = UserLevel.HOST)
-    @PutMapping("/{eventNo}")
+    @PutMapping
     public void modifyEventsInfo(@RequestBody EventDTO eventDTO, @CurrentLoginUserNo long userNo) {
         eventService.modifyEventsInfo(eventDTO, userNo);
 
@@ -146,10 +146,10 @@ public class EventController {
     /**
      * 주최자 이벤트 삭제 기능
      * @param eventNo
-     * @return
+     * @return void
      */
     @CheckLoginStatus(auth = UserLevel.HOST)
-    @DeleteMapping("/{eventNo}")
+    @DeleteMapping
     public void deleteEvent(long eventNo, @CurrentLoginUserNo long userNo) {
         eventService.deleteEventNo(eventNo, userNo);
     }

--- a/src/main/java/com/festa/controller/EventController.java
+++ b/src/main/java/com/festa/controller/EventController.java
@@ -54,7 +54,7 @@ public class EventController {
      * @return {@literal ResponseEntity<HttpStatus>}
      */
     @CheckLoginStatus(auth = UserLevel.USER)
-    @PostMapping("/applies")
+    @PostMapping("/{eventNo}/applies")
     public ResponseEntity<HttpStatus> applyForEvents(@RequestBody Participants participants) {
         try {
             eventService.applyForEvents(participants);

--- a/src/main/java/com/festa/controller/MemberController.java
+++ b/src/main/java/com/festa/controller/MemberController.java
@@ -69,7 +69,7 @@ public class MemberController {
      * @return {@literal ResponseEntity<MemberDTO>}
      */
     @CheckLoginStatus(auth = UserLevel.USER)
-    @GetMapping("/{userNo}")
+    @GetMapping
     public ResponseEntity<HttpStatus> getUser(@RequestParam long userNo) {
         MemberDTO memberInfo = memberService.getUser(userNo);
 
@@ -85,7 +85,7 @@ public class MemberController {
      * @return {@literal ResponseEntity<HttpStatus>}
      */
     @CheckLoginStatus(auth = UserLevel.USER)
-    @PutMapping("/{userNo}")
+    @PutMapping
     public void modifyMemberInfo(@RequestBody MemberInfo memberInfo) {
         boolean isUserModifyInfo = memberInfo.isUserModifyInfo();
 
@@ -103,7 +103,7 @@ public class MemberController {
      * @param userId
      * @return {@literal ResponseEntity<HttpStatus>}
      */
-    @GetMapping("/{userId}/delete")
+    @GetMapping("/delete")
     public void isIdDeleted(@RequestParam String userId, @RequestParam String password) {
         memberService.isUserIdExist(userId, password);
     }
@@ -152,8 +152,8 @@ public class MemberController {
      * @return {@literal ResponseEntity<HttpStatus>}
      */
     @CheckLoginStatus(auth = UserLevel.USER)
-    @DeleteMapping("/")
-    public void memberWithdraw(@CurrentLoginUserNo long userNo, String password) {
+    @DeleteMapping
+    public void memberWithdraw(@CurrentLoginUserNo long userNo) {
         memberService.memberWithdraw(userNo);
     }
 }


### PR DESCRIPTION
### MemberController 
- {} 식으로 userId나 userNo 받아오는 엔드포인트 변경
- 회원탈퇴 `memberWithdraw` 에서 `password` 는 받아올 필요가없어 삭제
- MemberControllerTests 수정

### EventController
- 마찬가지로 userId, userNo를 엔드포인트에 명시한 부분을 제거
- 기타 javadoc의 리턴타입 잘못기재한 부분 수정